### PR TITLE
watch source files and re-minify bundles on change

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# 🐉 dragon-bundles: code of conduct
+
+## our pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## our standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## enforcement responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+cadamsmith.dev@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## enforcement guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. temporary ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. permanent ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/src/DragonBundles/BundleProvider.cs
+++ b/src/DragonBundles/BundleProvider.cs
@@ -5,7 +5,10 @@ abstract class BundleProvider<T>(IWebHostEnvironment env, string bundleDirectory
 {
     readonly Dictionary<string, T> _bundles = [];
     readonly bool _isDevelopment = env.IsEnvironment(Environments.Development);
+    readonly IFileProvider _webRootFileProvider = env.WebRootFileProvider;
     protected readonly string WebRootPath = env.WebRootPath;
+
+    readonly Lock _rebuildLock = new();
 
     protected abstract string Extension { get; }
     protected virtual string ConcatenationToken => Environment.NewLine;
@@ -23,9 +26,38 @@ abstract class BundleProvider<T>(IWebHostEnvironment env, string bundleDirectory
             {
                 bundle.Version = ComputeVersion(bundle.MinifiedContent);
             }
+            WatchBundle(bundle);
         }
 
         _bundles[name] = bundle;
+    }
+
+    void WatchBundle(T bundle)
+    {
+        List<IChangeToken> tokens = [.. bundle.SourceFiles
+            .Select(f => _webRootFileProvider.Watch(f.TrimStart('/')))];
+        CompositeChangeToken composite = new(tokens);
+        composite.RegisterChangeCallback(_ => RebuildBundle(bundle), null);
+    }
+
+    void RebuildBundle(T bundle)
+    {
+        WatchBundle(bundle);
+        try
+        {
+            lock (_rebuildLock)
+            {
+                Minify(bundle);
+                if (bundle.MinifiedContent.Length > 0)
+                {
+                    bundle.Version = ComputeVersion(bundle.MinifiedContent);
+                }
+            }
+        }
+        catch (IOException)
+        {
+            // Source file may be mid-write; bundle retains previous content until the next change.
+        }
     }
 
     public string GetUrl(string name)
@@ -53,7 +85,7 @@ abstract class BundleProvider<T>(IWebHostEnvironment env, string bundleDirectory
 
     List<string> ResolveSourceUrls(string[] patterns)
     {
-        List<string> result = new();
+        List<string> result = [];
         foreach (string pattern in patterns)
         {
             if (!pattern.Contains('*') && !pattern.Contains('?'))
@@ -103,14 +135,12 @@ abstract class BundleProvider<T>(IWebHostEnvironment env, string bundleDirectory
 
     sealed class BundleFileInfo(T bundle) : IFileInfo
     {
-        static readonly Encoding _encoding = Encoding.UTF8;
-
         public bool Exists => true;
         public bool IsDirectory => false;
         public string Name => bundle.Name;
         public string? PhysicalPath => null;
         public DateTimeOffset LastModified => bundle.LastModified;
-        public long Length => _encoding.GetByteCount(bundle.MinifiedContent);
-        public Stream CreateReadStream() => new MemoryStream(_encoding.GetBytes(bundle.MinifiedContent));
+        public long Length => Encoding.UTF8.GetByteCount(bundle.MinifiedContent);
+        public Stream CreateReadStream() => new MemoryStream(Encoding.UTF8.GetBytes(bundle.MinifiedContent));
     }
 }

--- a/src/DragonBundles/GlobalUsings.cs
+++ b/src/DragonBundles/GlobalUsings.cs
@@ -1,6 +1,7 @@
 global using System.Security.Cryptography;
 global using System.Text;
 global using System.Text.RegularExpressions;
+global using System.Threading;
 global using Microsoft.AspNetCore.Builder;
 global using Microsoft.AspNetCore.Hosting;
 global using Microsoft.AspNetCore.Razor.TagHelpers;

--- a/src/DragonBundles/SystemWeb/HtmlHelperExtensions.cs
+++ b/src/DragonBundles/SystemWeb/HtmlHelperExtensions.cs
@@ -2,9 +2,12 @@ namespace DragonBundles;
 
 public static class HtmlHelperExtensions
 {
-    public static IHtmlString StyleBundle(this HtmlHelper helper, string name) =>
-        Styles.Render($"~/bundles/css/{name}");
+    extension(HtmlHelper helper)
+    {
+        public static IHtmlString StyleBundle(string name) =>
+            Styles.Render($"~/bundles/css/{name}");
 
-    public static IHtmlString ScriptBundle(this HtmlHelper helper, string name) =>
-        Scripts.Render($"~/bundles/js/{name}");
+        public static IHtmlString ScriptBundle(string name) =>
+            Scripts.Render($"~/bundles/js/{name}");
+    }
 }

--- a/tests/DragonBundles.Tests/BundlingIntegrationTests.cs
+++ b/tests/DragonBundles.Tests/BundlingIntegrationTests.cs
@@ -39,7 +39,7 @@ public class BundlingTestFixture : IAsyncLifetime
 
     public async Task DisposeAsync()
     {
-        Client?.Dispose();
+        Client.Dispose();
         if (_app != null)
         {
             await _app.DisposeAsync();

--- a/tests/DragonBundles.Tests/ScriptBundleProviderTests.cs
+++ b/tests/DragonBundles.Tests/ScriptBundleProviderTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.FileProviders;
 using NSubstitute;
@@ -16,6 +17,7 @@ public class ScriptBundleProviderTests : IDisposable
         IWebHostEnvironment? env = Substitute.For<IWebHostEnvironment>();
         env.EnvironmentName.Returns(envName);
         env.WebRootPath.Returns(_webRoot);
+        env.WebRootFileProvider.Returns(new NullFileProvider());
         return new ScriptBundleProvider(env);
     }
 
@@ -179,5 +181,39 @@ public class ScriptBundleProviderTests : IDisposable
         ScriptBundleProvider provider = MakeProvider(Environments.Production);
         IFileInfo fileInfo = provider.GetFileInfo("/wwwroot/js/app.js");
         Assert.False(fileInfo.Exists);
+    }
+
+    [Fact]
+    public async Task Add_InProduction_ReminifiesWhenSourceFileChanges()
+    {
+        WriteJsFile("/js/app.js", "var x = 1;");
+        using PhysicalFileProvider fileProvider = new(_webRoot);
+
+        IWebHostEnvironment env = Substitute.For<IWebHostEnvironment>();
+        env.EnvironmentName.Returns(Environments.Production);
+        env.WebRootPath.Returns(_webRoot);
+        env.WebRootFileProvider.Returns(fileProvider);
+
+        ScriptBundleProvider provider = new(env);
+        provider.Add("app", "/js/app.js");
+
+        IFileInfo initial = provider.GetFileInfo("/bundles/js/app.min.js");
+        await using Stream initialStream = initial.CreateReadStream();
+        string initialContent = await new StreamReader(initialStream).ReadToEndAsync();
+
+        WriteJsFile("/js/app.js", "var y = 2;");
+
+        string updatedContent = initialContent;
+        Stopwatch sw = Stopwatch.StartNew();
+        while (sw.Elapsed.TotalSeconds < 5 && updatedContent == initialContent)
+        {
+            await Task.Delay(100);
+            IFileInfo updated = provider.GetFileInfo("/bundles/js/app.min.js");
+            await using Stream s = updated.CreateReadStream();
+            updatedContent = await new StreamReader(s).ReadToEndAsync();
+        }
+
+        Assert.NotEqual(initialContent, updatedContent);
+        Assert.Contains("y", updatedContent);
     }
 }

--- a/tests/DragonBundles.Tests/ScriptTagHelperTests.cs
+++ b/tests/DragonBundles.Tests/ScriptTagHelperTests.cs
@@ -19,7 +19,7 @@ public class ScriptTagHelperTests : IDisposable
         File.WriteAllText(full, content);
     }
 
-    (ScriptTagHelper helper, TagHelperOutput output) MakeTagHelper(string envName, string bundleName, params string[] sourceFiles)
+    TagHelperOutput MakeTagHelper(string envName, string bundleName, params string[] sourceFiles)
     {
         IWebHostEnvironment? env = Substitute.For<IWebHostEnvironment>();
         env.EnvironmentName.Returns(envName);
@@ -40,13 +40,13 @@ public class ScriptTagHelperTests : IDisposable
         TagHelperOutput output = new("script-bundle", [], (_, _) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
 
         helper.Process(context, output);
-        return (helper, output);
+        return output;
     }
 
     [Fact]
     public void Process_InDevelopment_RendersIndividualScriptTags()
     {
-        (_, TagHelperOutput output) = MakeTagHelper(Environments.Development, "app", "/js/a.js", "/js/b.js");
+        TagHelperOutput output = MakeTagHelper(Environments.Development, "app", "/js/a.js", "/js/b.js");
         string? html = output.Content.GetContent();
 
         Assert.Contains("src=\"/js/a.js\"", html);
@@ -58,7 +58,7 @@ public class ScriptTagHelperTests : IDisposable
     public void Process_InProduction_RendersSingleBundleTag()
     {
         WriteJsFile("/js/a.js", "var x=1;");
-        (_, TagHelperOutput output) = MakeTagHelper(Environments.Production, "app", "/js/a.js");
+        TagHelperOutput output = MakeTagHelper(Environments.Production, "app", "/js/a.js");
         string? html = output.Content.GetContent();
 
         Assert.Contains("src=\"/bundles/js/app.min.js?v=", html);
@@ -68,14 +68,14 @@ public class ScriptTagHelperTests : IDisposable
     [Fact]
     public void Process_SuppressesOriginalTag()
     {
-        (_, TagHelperOutput output) = MakeTagHelper(Environments.Production, "app");
+        TagHelperOutput output = MakeTagHelper(Environments.Production, "app");
         Assert.Null(output.TagName);
     }
 
     [Fact]
     public void Process_InDevelopment_IncludesBundleAttribute()
     {
-        (_, TagHelperOutput output) = MakeTagHelper(Environments.Development, "app", "/js/a.js");
+        TagHelperOutput output = MakeTagHelper(Environments.Development, "app", "/js/a.js");
         Assert.Contains("data-bundle=\"app\"", output.Content.GetContent());
     }
 }

--- a/tests/DragonBundles.Tests/StyleBundleProviderTests.cs
+++ b/tests/DragonBundles.Tests/StyleBundleProviderTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.FileProviders;
 using NSubstitute;
@@ -16,6 +17,7 @@ public class StyleBundleProviderTests : IDisposable
         IWebHostEnvironment? env = Substitute.For<IWebHostEnvironment>();
         env.EnvironmentName.Returns(envName);
         env.WebRootPath.Returns(_webRoot);
+        env.WebRootFileProvider.Returns(new NullFileProvider());
         return new StyleBundleProvider(env);
     }
 
@@ -270,5 +272,39 @@ public class StyleBundleProviderTests : IDisposable
         using Stream stream = fileInfo.CreateReadStream();
         string content = new StreamReader(stream).ReadToEnd();
         Assert.Contains("#myMask", content);
+    }
+
+    [Fact]
+    public async Task Add_InProduction_ReminifiesWhenSourceFileChanges()
+    {
+        WriteCssFile("/css/site.css", "body { color: red; }");
+        using PhysicalFileProvider fileProvider = new(_webRoot);
+
+        IWebHostEnvironment env = Substitute.For<IWebHostEnvironment>();
+        env.EnvironmentName.Returns(Environments.Production);
+        env.WebRootPath.Returns(_webRoot);
+        env.WebRootFileProvider.Returns(fileProvider);
+
+        StyleBundleProvider provider = new(env);
+        provider.Add("site", "/css/site.css");
+
+        IFileInfo initial = provider.GetFileInfo("/bundles/css/site.min.css");
+        await using Stream initialStream = initial.CreateReadStream();
+        string initialContent = await new StreamReader(initialStream).ReadToEndAsync();
+
+        WriteCssFile("/css/site.css", "h1 { font-size: 42px; }");
+
+        string updatedContent = initialContent;
+        Stopwatch sw = Stopwatch.StartNew();
+        while (sw.Elapsed.TotalSeconds < 5 && updatedContent == initialContent)
+        {
+            await Task.Delay(100);
+            IFileInfo updated = provider.GetFileInfo("/bundles/css/site.min.css");
+            await using Stream s = updated.CreateReadStream();
+            updatedContent = await new StreamReader(s).ReadToEndAsync();
+        }
+
+        Assert.NotEqual(initialContent, updatedContent);
+        Assert.Contains("42px", updatedContent);
     }
 }

--- a/tests/DragonBundles.Tests/StyleTagHelperTests.cs
+++ b/tests/DragonBundles.Tests/StyleTagHelperTests.cs
@@ -19,7 +19,7 @@ public class StyleTagHelperTests : IDisposable
         File.WriteAllText(full, content);
     }
 
-    (StyleTagHelper helper, TagHelperOutput output) MakeTagHelper(string envName, string bundleName, params string[] sourceFiles)
+    TagHelperOutput MakeTagHelper(string envName, string bundleName, params string[] sourceFiles)
     {
         IWebHostEnvironment? env = Substitute.For<IWebHostEnvironment>();
         env.EnvironmentName.Returns(envName);
@@ -40,13 +40,13 @@ public class StyleTagHelperTests : IDisposable
         TagHelperOutput output = new("style-bundle", [], (_, _) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
 
         helper.Process(context, output);
-        return (helper, output);
+        return output;
     }
 
     [Fact]
     public void Process_InDevelopment_RendersIndividualLinkTags()
     {
-        (_, TagHelperOutput output) = MakeTagHelper(Environments.Development, "site", "/css/a.css", "/css/b.css");
+        TagHelperOutput output = MakeTagHelper(Environments.Development, "site", "/css/a.css", "/css/b.css");
         string? html = output.Content.GetContent();
 
         Assert.Contains("href=\"/css/a.css\"", html);
@@ -58,7 +58,7 @@ public class StyleTagHelperTests : IDisposable
     public void Process_InProduction_RendersSingleBundleTag()
     {
         WriteCssFile("/css/a.css", "body { color: red; }");
-        (_, TagHelperOutput output) = MakeTagHelper(Environments.Production, "site", "/css/a.css");
+        TagHelperOutput output = MakeTagHelper(Environments.Production, "site", "/css/a.css");
         string? html = output.Content.GetContent();
 
         Assert.Contains("href=\"/bundles/css/site.min.css?v=", html);
@@ -68,14 +68,14 @@ public class StyleTagHelperTests : IDisposable
     [Fact]
     public void Process_SuppressesOriginalTag()
     {
-        (_, TagHelperOutput output) = MakeTagHelper(Environments.Production, "site");
+        TagHelperOutput output = MakeTagHelper(Environments.Production, "site");
         Assert.Null(output.TagName);
     }
 
     [Fact]
     public void Process_InDevelopment_IncludesBundleAttribute()
     {
-        (_, TagHelperOutput output) = MakeTagHelper(Environments.Development, "site", "/css/a.css");
+        TagHelperOutput output = MakeTagHelper(Environments.Development, "site", "/css/a.css");
         Assert.Contains("data-bundle=\"site\"", output.Content.GetContent());
     }
 }

--- a/tests/DragonBundles.Tests/SystemWeb/BundleCollectionExtensionsTests.cs
+++ b/tests/DragonBundles.Tests/SystemWeb/BundleCollectionExtensionsTests.cs
@@ -4,7 +4,7 @@ namespace DragonBundles.Tests.SystemWeb;
 
 public class BundleCollectionExtensionsTests
 {
-    static BundleCollection MakeBundles() => new();
+    static BundleCollection MakeBundles() => [];
 
     [Fact]
     public void AddStyleBundle_RegistersBundleWithCorrectVirtualPath()

--- a/tests/DragonBundles.Tests/SystemWeb/NUglifyTransformTests.cs
+++ b/tests/DragonBundles.Tests/SystemWeb/NUglifyTransformTests.cs
@@ -35,7 +35,7 @@ public class NUglifyTransformTests
         NUglifyStyleTransform transform = new();
         BundleResponse response = MakeResponse("body{}");
 
-        Exception ex = Record.Exception(() => transform.Process(null!, response));
+        Exception? ex = Record.Exception(() => transform.Process(null!, response));
         Assert.Null(ex);
     }
 
@@ -68,7 +68,7 @@ public class NUglifyTransformTests
         NUglifyScriptTransform transform = new();
         BundleResponse response = MakeResponse("var x=1;");
 
-        Exception ex = Record.Exception(() => transform.Process(null!, response));
+        Exception? ex = Record.Exception(() => transform.Process(null!, response));
         Assert.Null(ex);
     }
 }


### PR DESCRIPTION
In non-Development environments, bundles are minified once at startup and stale until the app restarts. This PR watches each bundle's source files and re-runs minification whenever one changes.

Closes #4

## What changed

- `BundleProvider<T>` captures `WebRootFileProvider` and, after the initial minification, registers a `CompositeChangeToken` across all source files
- When any token fires, the bundle is re-minified under a lock (re-watch happens first to close the window where a rapid second save could be missed); `IOException` is swallowed so a mid-write file leaves the previous content in place until the next change
- Development mode is unaffected — tag helpers still render individual source tags there, so no watching is needed
- `MakeProvider` in both provider test classes now configures `WebRootFileProvider` with a `NullFileProvider` (callbacks never fire, keeping existing tests isolated)
- New async tests write a modified file and poll up to 5 s for the bundle to reflect the updated content
