### PR TITLE
add XML doc comments to public API and enable GenerateDocumentationFile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
-# CLAUDE.md
+# 🐉 dragon-bundles: claude.md
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Commands
+## commands
 
 ```bash
 dotnet build                                        # build the solution
@@ -11,7 +11,7 @@ dotnet test --filter "FullyQualifiedName~StyleBundle"  # run a single test class
 dotnet pack                                         # produce the NuGet .nupkg
 ```
 
-## Architecture
+## architecture
 
 DragonBundles is a multi-targeted NuGet library supporting two runtimes:
 
@@ -20,7 +20,7 @@ DragonBundles is a multi-targeted NuGet library supporting two runtimes:
 
 The two TFMs have entirely separate source files. `src/DragonBundles/` contains the net10.0 implementation; `src/DragonBundles/SystemWeb/` contains the net48 implementation. MSBuild ItemGroup conditions in the `.csproj` select the right set per TFM.
 
-### Public API surface — net10.0
+### public api surface — net10.0
 
 Only four types are public — everything else is `internal`:
 
@@ -29,7 +29,7 @@ Only four types are public — everything else is `internal`:
 - `StyleTagHelper` — `<style-bundle name="...">` Razor tag helper
 - `ScriptTagHelper` — `<script-bundle name="...">` Razor tag helper
 
-### Internal type hierarchy — net10.0
+### internal type hierarchy — net10.0
 
 ```
 Bundle (abstract)
@@ -47,15 +47,16 @@ BundleTagHelper<TProvider, TBundle> : TagHelper (abstract)
 BundleConfigurator : IBundleConfigurator
 ```
 
-### Request flow — net10.0
+### request flow — net10.0
 
 1. `AddBundling()` registers `StyleBundleProvider` and `ScriptBundleProvider` as singletons.
 2. `UseBundling(configure)` runs the configure action (populating the providers), then calls `UseStaticFiles` with a `CompositeFileProvider` that layers the two bundle providers over `WebRootFileProvider`.
-3. At startup, `BundleProvider<T>.Add()` calls `Minify()` immediately in non-Development environments; in Development it skips minification and the tag helpers render individual source file tags instead.
-4. Tag helpers use `Environments.Development` (not a custom string) to detect environment.
-5. Minified content is served in-memory via `BundleFileInfo : IFileInfo` — no files are written to disk.
+3. At startup, `BundleProvider<T>.Add()` resolves glob patterns via `Microsoft.Extensions.FileSystemGlobbing`, then in non-Development environments calls `Minify()` and hashes the result into `bundle.Version` (8-char lowercase hex SHA-256). Missing source files throw `FileNotFoundException`.
+4. In non-Development environments, `WatchBundle()` registers `IChangeToken` watchers on each source file. Any change triggers `RebuildBundle()`, which re-minifies and re-hashes under `_rebuildLock` to serialize concurrent rebuilds. An `IOException` during rebuild is silently swallowed — the bundle retains its previous content until the next change.
+5. Tag helpers use `Environments.Development` (not a custom string) to detect environment. `GetUrl()` appends `?v={bundle.Version}` to production bundle URLs for cache busting.
+6. Minified content is served in-memory via `BundleFileInfo : IFileInfo` — no files are written to disk.
 
-### Public API surface — net48
+### public api surface — net48
 
 Two types are public:
 
@@ -67,20 +68,25 @@ Two types are internal:
 - `NUglifyStyleTransform : IBundleTransform` — replaces WebGrease's `CssMinify`
 - `NUglifyScriptTransform : IBundleTransform` — replaces WebGrease's `JsMinify`
 
-### Minification
+### minification
 
 Uses **NUglify** (`Uglify.Css` / `Uglify.Js`) on both TFMs.
 
-- net10.0: called at startup in `BundleProvider<T>.Minify()`, reading from `env.WebRootPath`.
+- net10.0: called at startup in `BundleProvider<T>.Minify()`, reading from `env.WebRootPath`. Also re-triggered by file watching (non-Development only).
 - net48: called at request time by `System.Web.Optimization` via the `IBundleTransform` pipeline.
 
-### Tests
+CSS files are preprocessed by `StyleBundleProvider.TransformFileContent()` before concatenation: relative `url()` references are rewritten to absolute paths so stylesheets from different directories compose correctly after bundling.
+
+JS files are separated by `;\n` before concatenation (`ScriptBundleProvider.ConcatenationToken`) to guard against ASI hazards at file boundaries.
+
+### tests
 
 Tests live in `tests/DragonBundles.Tests/`. Internal types are exposed via `InternalsVisibleTo`. The project also multi-targets `net10.0;net48` using the same conditional compile pattern as the main library.
 
 **net10.0 tests** (root of `tests/DragonBundles.Tests/`):
 - `StyleBundleProviderTests` / `ScriptBundleProviderTests` — provider logic. Tests that write files use a per-test temp directory cleaned up via `IDisposable`.
 - `StyleTagHelperTests` / `ScriptTagHelperTests` — tag helper HTML output in dev vs production. Use real `TagHelperContext`/`TagHelperOutput` — no mocking needed.
+- `BundlingIntegrationTests` — end-to-end HTTP tests using `TestServer` via `BundlingTestFixture` (`IClassFixture`). Verifies bundles are served at the correct URLs with correct content types and minified content; also confirms static files still pass through the `CompositeFileProvider`.
 
 **net48 tests** (`tests/DragonBundles.Tests/SystemWeb/`):
 - `NUglifyTransformTests` — `IBundleTransform` implementations. Uses a real `BundleResponse` with `null` context (transforms don't access context).
@@ -88,6 +94,6 @@ Tests live in `tests/DragonBundles.Tests/`. Internal types are exposed via `Inte
 
 net48 tests compile on Mac but only run on Windows. CI runs them on a `windows-latest` GitHub Actions runner.
 
-### Target frameworks
+### target frameworks
 
 `net10.0;net48`. ASP.NET Core types come from `<FrameworkReference Include="Microsoft.AspNetCore.App" />` (net10.0 only). System.Web types come from `Microsoft.AspNet.Web.Optimization` and `Microsoft.AspNet.Mvc` NuGet packages (net48 only). `Microsoft.NETFramework.ReferenceAssemblies` enables cross-compilation of the net48 target on Mac.

--- a/README.md
+++ b/README.md
@@ -60,10 +60,22 @@ In **Development**, each source file gets its own tag:
 In **Production**, a single minified bundle is rendered:
 
 ```html
-<link rel="stylesheet" href="/bundles/css/site.min.css" data-bundle="site" />
+<link rel="stylesheet" href="/bundles/css/site.min.css?v=a1b2c3d4" data-bundle="site" />
 ```
 
-Bundles are minified at startup and served in-memory — no files are written to disk.
+The `?v=...` suffix is a content hash for cache busting, updated automatically whenever source files change.
+
+Bundles are minified at startup and served in-memory — no files are written to disk. In non-Development environments, source files are watched for changes and re-minified automatically without a restart.
+
+Relative `url()` references in CSS files are rewritten to absolute paths before minification, so stylesheets from different directories compose correctly.
+
+Source file paths accept glob patterns:
+
+```csharp
+bundles.AddStyleBundle("site", "/css/**/*.css");
+```
+
+Missing source files throw `FileNotFoundException` at startup.
 
 ## classic asp.net / system.web (.net framework 4.8)
 

--- a/src/DragonBundles/BundlingExtensions.cs
+++ b/src/DragonBundles/BundlingExtensions.cs
@@ -1,7 +1,9 @@
 namespace DragonBundles;
 
+/// <summary>Extension methods for registering DragonBundles with ASP.NET Core.</summary>
 public static class BundlingExtensions
 {
+    /// <summary>Registers DragonBundles services with the dependency injection container.</summary>
     public static IServiceCollection AddBundling(this IServiceCollection services)
     {
         services.AddSingleton<StyleBundleProvider>();
@@ -9,6 +11,10 @@ public static class BundlingExtensions
         return services;
     }
 
+    /// <summary>
+    /// Configures bundles and adds the DragonBundles static file middleware.
+    /// In non-Development environments, bundles are minified at startup and re-minified automatically when source files change.
+    /// </summary>
     public static IApplicationBuilder UseBundling(this IApplicationBuilder app, Action<IBundleConfigurator> configure)
     {
         StyleBundleProvider styles = app.ApplicationServices.GetRequiredService<StyleBundleProvider>();

--- a/src/DragonBundles/DragonBundles.csproj
+++ b/src/DragonBundles/DragonBundles.csproj
@@ -14,6 +14,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/cadamsmith/dragon-bundles</RepositoryUrl>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <!-- Always exclude SystemWeb files from the default compile glob -->

--- a/src/DragonBundles/IBundleConfigurator.cs
+++ b/src/DragonBundles/IBundleConfigurator.cs
@@ -1,7 +1,15 @@
 namespace DragonBundles;
 
+/// <summary>Fluent interface for registering CSS and JavaScript bundles.</summary>
 public interface IBundleConfigurator
 {
+    /// <summary>Registers a CSS bundle.</summary>
+    /// <param name="name">Bundle name. Served at <c>/bundles/css/{name}.min.css</c> in production.</param>
+    /// <param name="files">Source file paths relative to the web root. Glob patterns are supported.</param>
     IBundleConfigurator AddStyleBundle(string name, params string[] files);
+
+    /// <summary>Registers a JavaScript bundle.</summary>
+    /// <param name="name">Bundle name. Served at <c>/bundles/js/{name}.min.js</c> in production.</param>
+    /// <param name="files">Source file paths relative to the web root. Glob patterns are supported.</param>
     IBundleConfigurator AddScriptBundle(string name, params string[] files);
 }

--- a/src/DragonBundles/ScriptTagHelper.cs
+++ b/src/DragonBundles/ScriptTagHelper.cs
@@ -1,11 +1,17 @@
 namespace DragonBundles;
 
+/// <summary>
+/// Renders a JavaScript bundle. In Development, emits one <c>&lt;script&gt;</c> per source file;
+/// in production, emits a single minified bundle script with a content-hash cache-busting suffix.
+/// </summary>
 [HtmlTargetElement("script-bundle", TagStructure = TagStructure.NormalOrSelfClosing)]
 public sealed class ScriptTagHelper(IServiceProvider services, IWebHostEnvironment env) : TagHelper
 {
+    /// <summary>The bundle name, as registered via <see cref="IBundleConfigurator.AddScriptBundle"/>.</summary>
     [HtmlAttributeName("name")]
     public required string Name { get; set; }
 
+    /// <inheritdoc />
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {
         ScriptBundleProvider provider = services.GetRequiredService<ScriptBundleProvider>();

--- a/src/DragonBundles/StyleTagHelper.cs
+++ b/src/DragonBundles/StyleTagHelper.cs
@@ -1,11 +1,17 @@
 namespace DragonBundles;
 
+/// <summary>
+/// Renders a CSS bundle. In Development, emits one <c>&lt;link&gt;</c> per source file;
+/// in production, emits a single minified bundle link with a content-hash cache-busting suffix.
+/// </summary>
 [HtmlTargetElement("style-bundle", TagStructure = TagStructure.NormalOrSelfClosing)]
 public sealed class StyleTagHelper(IServiceProvider services, IWebHostEnvironment env) : TagHelper
 {
+    /// <summary>The bundle name, as registered via <see cref="IBundleConfigurator.AddStyleBundle"/>.</summary>
     [HtmlAttributeName("name")]
     public required string Name { get; set; }
 
+    /// <inheritdoc />
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {
         StyleBundleProvider provider = services.GetRequiredService<StyleBundleProvider>();

--- a/src/DragonBundles/SystemWeb/BundleCollectionExtensions.cs
+++ b/src/DragonBundles/SystemWeb/BundleCollectionExtensions.cs
@@ -1,9 +1,13 @@
 namespace DragonBundles;
 
+/// <summary>Extension methods for registering DragonBundles with <c>System.Web.Optimization</c>.</summary>
 public static class BundleCollectionExtensions
 {
     extension(BundleCollection bundles)
     {
+        /// <summary>Registers a CSS bundle using NUglify minification.</summary>
+        /// <param name="name">Bundle name. Served at <c>~/bundles/css/{name}</c>.</param>
+        /// <param name="files">Source file virtual paths (e.g. <c>~/Content/site.css</c>).</param>
         public BundleCollection AddStyleBundle(string name, params string[] files)
         {
             StyleBundle bundle = new($"~/bundles/css/{name}");
@@ -18,6 +22,9 @@ public static class BundleCollectionExtensions
             return bundles;
         }
 
+        /// <summary>Registers a JavaScript bundle using NUglify minification.</summary>
+        /// <param name="name">Bundle name. Served at <c>~/bundles/js/{name}</c>.</param>
+        /// <param name="files">Source file virtual paths (e.g. <c>~/Scripts/app.js</c>).</param>
         public BundleCollection AddScriptBundle(string name, params string[] files)
         {
             ScriptBundle bundle = new($"~/bundles/js/{name}");

--- a/src/DragonBundles/SystemWeb/HtmlHelperExtensions.cs
+++ b/src/DragonBundles/SystemWeb/HtmlHelperExtensions.cs
@@ -1,12 +1,15 @@
 namespace DragonBundles;
 
+/// <summary>Extension methods for rendering DragonBundles in ASP.NET MVC Razor views.</summary>
 public static class HtmlHelperExtensions
 {
     extension(HtmlHelper helper)
     {
+        /// <summary>Renders the CSS bundle registered under <paramref name="name"/>.</summary>
         public static IHtmlString StyleBundle(string name) =>
             Styles.Render($"~/bundles/css/{name}");
 
+        /// <summary>Renders the JavaScript bundle registered under <paramref name="name"/>.</summary>
         public static IHtmlString ScriptBundle(string name) =>
             Scripts.Render($"~/bundles/js/{name}");
     }


### PR DESCRIPTION
Closes #5.

Adds `/// <summary>` comments to all six public types and their members (`IBundleConfigurator`, `BundlingExtensions`, `StyleTagHelper`, `ScriptTagHelper`, `BundleCollectionExtensions`, `HtmlHelperExtensions`) and sets `<GenerateDocumentationFile>true</GenerateDocumentationFile>` in the csproj so the XML file ships in the nupkg.

Also updates README and CLAUDE.md to document features added since they were last written: content-hash cache busting, file watching/hot-rebuild, CSS `url()` rewriting, JS ASI-guard semicolons, glob pattern support, and `BundlingIntegrationTests`.