### PR TITLE
send Cache-Control: immutable on bundle responses in production

### DIFF
--- a/src/DragonBundles/BundlingExtensions.cs
+++ b/src/DragonBundles/BundlingExtensions.cs
@@ -25,7 +25,14 @@ public static class BundlingExtensions
 
         app.UseStaticFiles(new StaticFileOptions
         {
-            FileProvider = new CompositeFileProvider(styles, scripts, webEnv.WebRootFileProvider)
+            FileProvider = new CompositeFileProvider(styles, scripts, webEnv.WebRootFileProvider),
+            OnPrepareResponse = ctx =>
+            {
+                if (!webEnv.IsDevelopment() && ctx.Context.Request.Path.StartsWithSegments("/bundles"))
+                {
+                    ctx.Context.Response.Headers.CacheControl = "public, max-age=31536000, immutable";
+                }
+            }
         });
 
         return app;

--- a/tests/DragonBundles.Tests/BundlingIntegrationTests.cs
+++ b/tests/DragonBundles.Tests/BundlingIntegrationTests.cs
@@ -122,4 +122,25 @@ public class BundlingIntegrationTests(BundlingTestFixture fixture) : IClassFixtu
         HttpResponseMessage response = await fixture.Client.GetAsync("/bundles/css/missing.min.css");
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
+
+    [Fact]
+    public async Task StyleBundle_HasLongLivedCacheControlHeader()
+    {
+        HttpResponseMessage response = await fixture.Client.GetAsync("/bundles/css/site.min.css");
+        Assert.Equal("public, max-age=31536000, immutable", response.Headers.CacheControl?.ToString());
+    }
+
+    [Fact]
+    public async Task ScriptBundle_HasLongLivedCacheControlHeader()
+    {
+        HttpResponseMessage response = await fixture.Client.GetAsync("/bundles/js/app.min.js");
+        Assert.Equal("public, max-age=31536000, immutable", response.Headers.CacheControl?.ToString());
+    }
+
+    [Fact]
+    public async Task StaticFile_DoesNotHaveLongLivedCacheControlHeader()
+    {
+        HttpResponseMessage response = await fixture.Client.GetAsync("/static.txt");
+        Assert.Null(response.Headers.CacheControl);
+    }
 }


### PR DESCRIPTION
Closes #2.

Bundle URLs are content-addressed via the `?v={hash}` query string, but without a corresponding `Cache-Control` header the version buster is wasted — browsers won't cache the responses long-term. This wires up `OnPrepareResponse` in `UseBundling` to send `Cache-Control: public, max-age=31536000, immutable` for any path under `/bundles/` in non-Development environments.

The `IsDevelopment()` guard is intentional: in Development the tag helpers don't append `?v=`, so the URL isn't content-addressed and long-lived caching would serve stale bundles.