### PR TITLE
fill out NuGet package metadata and enable SourceLink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Test
         run: dotnet test --no-build --configuration Release --framework net10.0
 
+      - name: Pack
+        run: dotnet pack --no-build --configuration Release -p:ContinuousIntegrationBuild=true
+
   test-net48:
     runs-on: windows-latest
 

--- a/src/DragonBundles/DragonBundles.csproj
+++ b/src/DragonBundles/DragonBundles.csproj
@@ -10,11 +10,22 @@
     <PackageId>DragonBundles</PackageId>
     <Version>0.1.0</Version>
     <Authors>cadamsmith</Authors>
-    <Description>DragonBundles</Description>
+    <Description>CSS and JS bundling and minification for ASP.NET Core and ASP.NET 4.x.</Description>
+    <PackageTags>bundling;minification;css;js;asp.net</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/cadamsmith/dragon-bundles</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!-- SourceLink -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+    <!-- Symbols -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <!-- Always exclude SystemWeb files from the default compile glob -->
@@ -33,7 +44,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="NUglify" Version="1.21.17" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">


### PR DESCRIPTION
Closes #6.

- Replace placeholder `Description` with a real one; add `PackageTags`, `PackageReadmeFile`, and `RepositoryType`
- Wire up `Microsoft.SourceLink.GitHub` with `PublishRepositoryUrl` and `EmbedUntrackedSources`
- Enable `IncludeSymbols` / `SymbolPackageFormat = snupkg` so a symbols package is produced alongside the main nupkg
- Include `README.md` in the package via a `None` item
- Add a `Pack` step to CI with `ContinuousIntegrationBuild=true` to verify the package builds cleanly on every push