### PR TITLE
skip .min.* and .map files in glob expansion; pass pre-minified literals through verbatim

### DIFF
--- a/src/DragonBundles/BundleProvider.cs
+++ b/src/DragonBundles/BundleProvider.cs
@@ -70,18 +70,19 @@ abstract class BundleProvider<T>(IWebHostEnvironment env, string bundleDirectory
 
     protected virtual string TransformFileContent(string content, string sourceUrl) => content;
 
-    protected string ReadSourceFiles(Bundle bundle) =>
-        string.Join(ConcatenationToken, bundle.SourceFiles.Select(f =>
+    protected string ReadSourceFile(string bundleName, string sourceUrl)
+    {
+        string path = Path.Combine(WebRootPath, sourceUrl.TrimStart('/'));
+        if (!File.Exists(path))
         {
-            string path = Path.Combine(WebRootPath, f.TrimStart('/'));
-            if (!File.Exists(path))
-            {
-                throw new FileNotFoundException(
-                    $"Bundle '{bundle.Name}': source file '{f}' not found.", path);
-            }
+            throw new FileNotFoundException(
+                $"Bundle '{bundleName}': source file '{sourceUrl}' not found.", path);
+        }
+        return TransformFileContent(File.ReadAllText(path), sourceUrl);
+    }
 
-            return TransformFileContent(File.ReadAllText(path), f);
-        }));
+    protected string ReadSourceFiles(Bundle bundle) =>
+        string.Join(ConcatenationToken, bundle.SourceFiles.Select(f => ReadSourceFile(bundle.Name, f)));
 
     List<string> ResolveSourceUrls(string[] patterns)
     {
@@ -100,7 +101,9 @@ abstract class BundleProvider<T>(IWebHostEnvironment env, string bundleDirectory
                 new DirectoryInfoWrapper(new DirectoryInfo(WebRootPath)));
             result.AddRange(matchResult.Files
                 .OrderBy(f => f.Path)
-                .Select(f => "/" + f.Path.Replace('\\', '/')));
+                .Select(f => "/" + f.Path.Replace('\\', '/'))
+                .Where(f => !f.EndsWith(".map", StringComparison.OrdinalIgnoreCase)
+                         && !f.Contains(".min.", StringComparison.OrdinalIgnoreCase)));
         }
         return result;
     }

--- a/src/DragonBundles/ScriptBundleProvider.cs
+++ b/src/DragonBundles/ScriptBundleProvider.cs
@@ -8,7 +8,13 @@ sealed class ScriptBundleProvider(IWebHostEnvironment env) : BundleProvider<Scri
 
     public override void Minify(ScriptBundle bundle)
     {
-        bundle.MinifiedContent = Uglify.Js(ReadSourceFiles(bundle)).Code;
+        bundle.MinifiedContent = string.Join(ConcatenationToken, bundle.SourceFiles.Select(f =>
+        {
+            string content = ReadSourceFile(bundle.Name, f);
+            return f.EndsWith(".min.js", StringComparison.OrdinalIgnoreCase)
+                ? content
+                : Uglify.Js(content).Code;
+        }));
         bundle.LastModified = DateTime.UtcNow;
     }
 }

--- a/src/DragonBundles/StyleBundleProvider.cs
+++ b/src/DragonBundles/StyleBundleProvider.cs
@@ -10,7 +10,13 @@ sealed partial class StyleBundleProvider(IWebHostEnvironment env) : BundleProvid
 
     public override void Minify(StyleBundle bundle)
     {
-        bundle.MinifiedContent = Uglify.Css(ReadSourceFiles(bundle)).Code;
+        bundle.MinifiedContent = string.Join(ConcatenationToken, bundle.SourceFiles.Select(f =>
+        {
+            string content = ReadSourceFile(bundle.Name, f);
+            return f.EndsWith(".min.css", StringComparison.OrdinalIgnoreCase)
+                ? content
+                : Uglify.Css(content).Code;
+        }));
         bundle.LastModified = DateTime.UtcNow;
     }
 

--- a/tests/DragonBundles.Tests/ScriptBundleProviderTests.cs
+++ b/tests/DragonBundles.Tests/ScriptBundleProviderTests.cs
@@ -139,6 +139,70 @@ public class ScriptBundleProviderTests : IDisposable
     }
 
     [Fact]
+    public void Add_WithGlobPattern_ExcludesPreMinifiedFiles()
+    {
+        WriteJsFile("/js/a.js", "var a = 1;");
+        WriteJsFile("/js/a.min.js", "var a=1;");
+        ScriptBundleProvider provider = MakeProvider(Environments.Development);
+
+        provider.Add("app", "/js/*.js");
+
+        Assert.Equal(["/js/a.js"], provider.GetSourceUrls("app"));
+    }
+
+    [Fact]
+    public void Add_WithGlobPattern_ExcludesSourceMaps()
+    {
+        WriteJsFile("/js/a.js", "var a = 1;");
+        WriteJsFile("/js/a.js.map", "{}");
+        ScriptBundleProvider provider = MakeProvider(Environments.Development);
+
+        provider.Add("app", "/js/*");
+
+        Assert.DoesNotContain("/js/a.js.map", provider.GetSourceUrls("app"));
+    }
+
+    [Fact]
+    public void Add_InProduction_PassesPreMinifiedLiteralThroughVerbatim()
+    {
+        string preMinified = "function hello(){return\"hi\";}var x=1;";
+        WriteJsFile("/js/app.min.js", preMinified);
+        ScriptBundleProvider provider = MakeProvider(Environments.Production);
+
+        provider.Add("app", "/js/app.min.js");
+
+        IFileInfo fileInfo = provider.GetFileInfo("/bundles/js/app.min.js");
+        using Stream stream = fileInfo.CreateReadStream();
+        string content = new StreamReader(stream).ReadToEnd();
+        Assert.Equal(preMinified, content);
+    }
+
+    [Fact]
+    public void Add_InProduction_MixedBundle_MinifiesNonPreMinifiedAndPreservesOrder()
+    {
+        WriteJsFile("/js/a.js", "var   a   =   1;");
+        WriteJsFile("/js/b.min.js", "var b=2;");
+        WriteJsFile("/js/c.js", "var   c   =   3;");
+        ScriptBundleProvider provider = MakeProvider(Environments.Production);
+
+        provider.Add("app", "/js/a.js", "/js/b.min.js", "/js/c.js");
+
+        IFileInfo fileInfo = provider.GetFileInfo("/bundles/js/app.min.js");
+        using Stream stream = fileInfo.CreateReadStream();
+        string content = new StreamReader(stream).ReadToEnd();
+
+        int posA = content.IndexOf("a=", StringComparison.Ordinal);
+        int posB = content.IndexOf("b=2", StringComparison.Ordinal);
+        int posC = content.IndexOf("c=", StringComparison.Ordinal);
+
+        Assert.True(posA >= 0);
+        Assert.True(posB >= 0);
+        Assert.True(posC >= 0);
+        Assert.True(posA < posB && posB < posC);
+        Assert.Contains("b=2", content);
+    }
+
+    [Fact]
     public void GetSourceUrls_ReturnsFiles_WhenBundleExists()
     {
         ScriptBundleProvider provider = MakeProvider(Environments.Development);

--- a/tests/DragonBundles.Tests/StyleBundleProviderTests.cs
+++ b/tests/DragonBundles.Tests/StyleBundleProviderTests.cs
@@ -123,6 +123,70 @@ public class StyleBundleProviderTests : IDisposable
     }
 
     [Fact]
+    public void Add_WithGlobPattern_ExcludesPreMinifiedFiles()
+    {
+        WriteCssFile("/css/a.css", "body {}");
+        WriteCssFile("/css/a.min.css", "body{}");
+        StyleBundleProvider provider = MakeProvider(Environments.Development);
+
+        provider.Add("site", "/css/*.css");
+
+        Assert.Equal(["/css/a.css"], provider.GetSourceUrls("site"));
+    }
+
+    [Fact]
+    public void Add_WithGlobPattern_ExcludesSourceMaps()
+    {
+        WriteCssFile("/css/a.css", "body {}");
+        WriteCssFile("/css/a.css.map", "{}");
+        StyleBundleProvider provider = MakeProvider(Environments.Development);
+
+        provider.Add("site", "/css/*");
+
+        Assert.DoesNotContain("/css/a.css.map", provider.GetSourceUrls("site"));
+    }
+
+    [Fact]
+    public void Add_InProduction_PassesPreMinifiedLiteralThroughVerbatim()
+    {
+        string preMinified = "body{color:red}h1{font-size:24px}";
+        WriteCssFile("/css/site.min.css", preMinified);
+        StyleBundleProvider provider = MakeProvider(Environments.Production);
+
+        provider.Add("site", "/css/site.min.css");
+
+        IFileInfo fileInfo = provider.GetFileInfo("/bundles/css/site.min.css");
+        using Stream stream = fileInfo.CreateReadStream();
+        string content = new StreamReader(stream).ReadToEnd();
+        Assert.Equal(preMinified, content);
+    }
+
+    [Fact]
+    public void Add_InProduction_MixedBundle_MinifiesNonPreMinifiedAndPreservesOrder()
+    {
+        WriteCssFile("/css/a.css", "body   {   color:   red;   }");
+        WriteCssFile("/css/b.min.css", "h1{font-size:24px}");
+        WriteCssFile("/css/c.css", "p   {   margin:   0;   }");
+        StyleBundleProvider provider = MakeProvider(Environments.Production);
+
+        provider.Add("site", "/css/a.css", "/css/b.min.css", "/css/c.css");
+
+        IFileInfo fileInfo = provider.GetFileInfo("/bundles/css/site.min.css");
+        using Stream stream = fileInfo.CreateReadStream();
+        string content = new StreamReader(stream).ReadToEnd();
+
+        int posA = content.IndexOf("color", StringComparison.Ordinal);
+        int posB = content.IndexOf("h1{font-size:24px}", StringComparison.Ordinal);
+        int posC = content.IndexOf("margin", StringComparison.Ordinal);
+
+        Assert.True(posA >= 0);
+        Assert.True(posB >= 0);
+        Assert.True(posC >= 0);
+        Assert.True(posA < posB && posB < posC);
+        Assert.Contains("h1{font-size:24px}", content);
+    }
+
+    [Fact]
     public void GetSourceUrls_ReturnsFiles_WhenBundleExists()
     {
         StyleBundleProvider provider = MakeProvider(Environments.Development);


### PR DESCRIPTION
Closes #3.

- Glob patterns in `ResolveSourceUrls` now exclude `*.min.*` (pre-minified) and `*.map` (source maps); literal includes are unaffected
- `Minify()` in both providers now processes files individually — files ending in `.min.css` / `.min.js` are passed through verbatim, all others go through NUglify
- CSS URL rewriting (`TransformFileContent`) still applies to pre-minified CSS files before inclusion
- Extracted `ReadSourceFile` helper from `ReadSourceFiles` to support per-file processing