### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 0.2.0)'
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Bump version in csproj
+        run: |
+          sed -i -E 's|<Version>[^<]*</Version>|<Version>${{ inputs.version }}</Version>|' src/DragonBundles/DragonBundles.csproj
+          grep -q "<Version>${{ inputs.version }}</Version>" src/DragonBundles/DragonBundles.csproj
+
+      - name: Commit, tag, push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git diff --quiet || git commit -am "Release v${{ inputs.version }}"
+          git tag "v${{ inputs.version }}"
+          git push origin main --follow-tags
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release -p:ContinuousIntegrationBuild=true
+
+      - name: Pack
+        run: dotnet pack --no-build --configuration Release -p:ContinuousIntegrationBuild=true --output ./artifacts
+
+      - name: Push to NuGet
+        run: dotnet nuget push "./artifacts/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh release create "v${{ inputs.version }}" --generate-notes


### PR DESCRIPTION
Adds `.github/workflows/release.yml`, a manual (`workflow_dispatch`) pipeline that bumps `<Version>` in the .csproj, commits and tags `vX.Y.Z` on main, builds and packs in Release, pushes to nuget.org, and creates a GitHub release with auto-generated notes.

Authenticates as a dedicated GitHub App (via `actions/create-github-app-token@v2`) so the commit + tag push bypasses the main ruleset without granting admin-wide bypass.

Required repo secrets: `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`, `NUGET_API_KEY`. Ruleset bypass for the App still needs to be added before the first run.

Refs #8.