### PR TITLE
add codeql code scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,52 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.tfm }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            tfm: net10.0
+          - os: windows-latest
+            tfm: net48
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: csharp
+          build-mode: manual
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release --framework ${{ matrix.tfm }} -p:ContinuousIntegrationBuild=true
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:csharp/tfm:${{ matrix.tfm }}"


### PR DESCRIPTION
Adds a CodeQL workflow that scans C# on push/PR to main and weekly (Mondays 06:00 UTC).

Matrix builds net10.0 on ubuntu-latest and net48 on windows-latest so the SystemWeb code is covered. Per-TFM `category` keeps results as separate sets in the Security tab.