### PR TITLE
fix release workflow tag and add pre-commit formatting hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+dotnet format --verify-no-changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git diff --quiet || git commit -am "Release v${{ inputs.version }}"
-          git tag "v${{ inputs.version }}"
+          git tag -a "v${{ inputs.version }}" -m "Release v${{ inputs.version }}"
           git push origin main --follow-tags
 
       - name: Restore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,12 @@ dotnet format          # fix
 dotnet format --verify-no-changes  # check only
 ```
 
+A pre-commit hook runs the check automatically. Enable it once after cloning:
+
+```bash
+git config core.hooksPath .githooks
+```
+
 ## project layout
 
 ```

--- a/src/DragonBundles/DragonBundles.csproj
+++ b/src/DragonBundles/DragonBundles.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet package metadata -->
     <PackageId>DragonBundles</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>cadamsmith</Authors>
     <Description>CSS and JS bundling and minification for ASP.NET Core and ASP.NET 4.x.</Description>
     <PackageTags>bundling;minification;css;js;asp.net</PackageTags>


### PR DESCRIPTION
- Fix release workflow using a lightweight tag that `--follow-tags` silently skipped; switch to annotated tag so it's pushed before `gh release create` runs
- Add `.githooks/pre-commit` that runs `dotnet format --verify-no-changes` to catch formatting issues before commit
- Bump version to 0.2.0