### PR TITLE
Auto-emit subresource integrity attributes on bundle tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,9 +51,9 @@ BundleConfigurator : IBundleConfigurator
 
 1. `AddBundling()` registers `StyleBundleProvider` and `ScriptBundleProvider` as singletons.
 2. `UseBundling(configure)` runs the configure action (populating the providers), then calls `UseStaticFiles` with a `CompositeFileProvider` that layers the two bundle providers over `WebRootFileProvider`.
-3. At startup, `BundleProvider<T>.Add()` resolves glob patterns via `Microsoft.Extensions.FileSystemGlobbing`, then in non-Development environments calls `Minify()` and hashes the result into `bundle.Version` (8-char lowercase hex SHA-256). Missing source files throw `FileNotFoundException`.
+3. At startup, `BundleProvider<T>.Add()` resolves glob patterns via `Microsoft.Extensions.FileSystemGlobbing`, then in non-Development environments calls `Minify()` and `UpdateHashes()`. The latter hashes the minified bytes once and derives both `bundle.Version` (8-char lowercase hex SHA-256, used for cache busting) and `bundle.Integrity` (`sha384-<base64>` SRI string). Missing source files throw `FileNotFoundException`.
 4. In non-Development environments, `WatchBundle()` registers `IChangeToken` watchers on each source file. Any change triggers `RebuildBundle()`, which re-minifies and re-hashes under `_rebuildLock` to serialize concurrent rebuilds. An `IOException` during rebuild is silently swallowed — the bundle retains its previous content until the next change.
-5. Tag helpers use `Environments.Development` (not a custom string) to detect environment. `GetUrl()` appends `?v={bundle.Version}` to production bundle URLs for cache busting.
+5. Tag helpers use `Environments.Development` (not a custom string) to detect environment. In production, `GetUrl()` appends `?v={bundle.Version}` for cache busting and the tag helpers stamp `integrity="sha384-..." crossorigin="anonymous"` from `GetIntegrity()`.
 6. Minified content is served in-memory via `BundleFileInfo : IFileInfo` — no files are written to disk.
 
 ### public api surface — net48

--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ In **Development**, each source file gets its own tag:
 <link rel="stylesheet" href="/css/layout.css" data-bundle="site" />
 ```
 
-In **Production**, a single minified bundle is rendered:
+In **Production**, a single minified bundle is rendered with a [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) hash:
 
 ```html
-<link rel="stylesheet" href="/bundles/css/site.min.css?v=a1b2c3d4" data-bundle="site" />
+<link rel="stylesheet" href="/bundles/css/site.min.css?v=a1b2c3d4" integrity="sha384-..." crossorigin="anonymous" data-bundle="site" />
 ```
 
-The `?v=...` suffix is a content hash for cache busting, updated automatically whenever source files change.
+The `?v=...` suffix is a content hash for cache busting, updated automatically whenever source files change. The `integrity` attribute is a SHA-384 hash of the bundle bytes the browser uses to verify the response wasn't tampered with.
 
 Bundles are minified at startup and served in-memory — no files are written to disk. In non-Development environments, source files are watched for changes and re-minified automatically without a restart.
 

--- a/src/DragonBundles/Bundle.cs
+++ b/src/DragonBundles/Bundle.cs
@@ -6,5 +6,6 @@ abstract class Bundle(string name, List<string> sourceFiles)
     public List<string> SourceFiles { get; set; } = sourceFiles;
     public string MinifiedContent { get; set; } = string.Empty;
     public string Version { get; set; } = string.Empty;
+    public string Integrity { get; set; } = string.Empty;
     public DateTime LastModified { get; set; } = DateTime.UtcNow;
 }

--- a/src/DragonBundles/BundleProvider.cs
+++ b/src/DragonBundles/BundleProvider.cs
@@ -22,10 +22,7 @@ abstract class BundleProvider<T>(IWebHostEnvironment env, string bundleDirectory
         if (!_isDevelopment)
         {
             Minify(bundle);
-            if (bundle.MinifiedContent.Length > 0)
-            {
-                bundle.Version = ComputeVersion(bundle.MinifiedContent);
-            }
+            UpdateHashes(bundle);
             WatchBundle(bundle);
         }
 
@@ -48,10 +45,7 @@ abstract class BundleProvider<T>(IWebHostEnvironment env, string bundleDirectory
             lock (_rebuildLock)
             {
                 Minify(bundle);
-                if (bundle.MinifiedContent.Length > 0)
-                {
-                    bundle.Version = ComputeVersion(bundle.MinifiedContent);
-                }
+                UpdateHashes(bundle);
             }
         }
         catch (IOException)
@@ -108,14 +102,23 @@ abstract class BundleProvider<T>(IWebHostEnvironment env, string bundleDirectory
         return result;
     }
 
-    static string ComputeVersion(string content)
+    static void UpdateHashes(Bundle bundle)
     {
-        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(content));
-        return Convert.ToHexString(hash)[..8].ToLowerInvariant();
+        if (bundle.MinifiedContent.Length == 0)
+        {
+            return;
+        }
+
+        byte[] bytes = Encoding.UTF8.GetBytes(bundle.MinifiedContent);
+        bundle.Version = Convert.ToHexString(SHA256.HashData(bytes))[..8].ToLowerInvariant();
+        bundle.Integrity = "sha384-" + Convert.ToBase64String(SHA384.HashData(bytes));
     }
 
     public List<string> GetSourceUrls(string name) =>
         _bundles.TryGetValue(name, out T? bundle) ? bundle.SourceFiles : [];
+
+    public string GetIntegrity(string name) =>
+        _bundles.TryGetValue(name, out T? bundle) ? bundle.Integrity : string.Empty;
 
     public IFileInfo GetFileInfo(string subpath)
     {

--- a/src/DragonBundles/ScriptTagHelper.cs
+++ b/src/DragonBundles/ScriptTagHelper.cs
@@ -18,16 +18,24 @@ public sealed class ScriptTagHelper(IServiceProvider services, IWebHostEnvironme
         output.TagName = null;
         output.SuppressOutput();
 
-        IEnumerable<string> tags = env.IsEnvironment(Environments.Development)
-            ? provider.GetSourceUrls(Name).Select(RenderTag)
-            : [$"{RenderTag(provider.GetUrl(Name))}\n"];
-
-        foreach (string tag in tags)
+        if (env.IsEnvironment(Environments.Development))
         {
-            output.Content.AppendHtml(tag);
+            foreach (string url in provider.GetSourceUrls(Name))
+            {
+                output.Content.AppendHtml(RenderTag(url, integrity: string.Empty));
+            }
+        }
+        else
+        {
+            output.Content.AppendHtml($"{RenderTag(provider.GetUrl(Name), provider.GetIntegrity(Name))}\n");
         }
     }
 
-    string RenderTag(string url) =>
-        $"<script src=\"{url}\" data-bundle=\"{Name}\"></script>";
+    string RenderTag(string url, string integrity)
+    {
+        string sri = integrity.Length > 0
+            ? $" integrity=\"{integrity}\" crossorigin=\"anonymous\""
+            : string.Empty;
+        return $"<script src=\"{url}\"{sri} data-bundle=\"{Name}\"></script>";
+    }
 }

--- a/src/DragonBundles/StyleTagHelper.cs
+++ b/src/DragonBundles/StyleTagHelper.cs
@@ -18,16 +18,24 @@ public sealed class StyleTagHelper(IServiceProvider services, IWebHostEnvironmen
         output.TagName = null;
         output.SuppressOutput();
 
-        IEnumerable<string> tags = env.IsEnvironment(Environments.Development)
-            ? provider.GetSourceUrls(Name).Select(RenderTag)
-            : [$"{RenderTag(provider.GetUrl(Name))}\n"];
-
-        foreach (string tag in tags)
+        if (env.IsEnvironment(Environments.Development))
         {
-            output.Content.AppendHtml(tag);
+            foreach (string url in provider.GetSourceUrls(Name))
+            {
+                output.Content.AppendHtml(RenderTag(url, integrity: string.Empty));
+            }
+        }
+        else
+        {
+            output.Content.AppendHtml($"{RenderTag(provider.GetUrl(Name), provider.GetIntegrity(Name))}\n");
         }
     }
 
-    string RenderTag(string url) =>
-        $"<link rel=\"stylesheet\" href=\"{url}\" data-bundle=\"{Name}\" />";
+    string RenderTag(string url, string integrity)
+    {
+        string sri = integrity.Length > 0
+            ? $" integrity=\"{integrity}\" crossorigin=\"anonymous\""
+            : string.Empty;
+        return $"<link rel=\"stylesheet\" href=\"{url}\"{sri} data-bundle=\"{Name}\" />";
+    }
 }

--- a/tests/DragonBundles.Tests/BundlingIntegrationTests.cs
+++ b/tests/DragonBundles.Tests/BundlingIntegrationTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
+using System.Security.Cryptography;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DragonBundles.Tests;
 
@@ -10,6 +12,7 @@ public class BundlingTestFixture : IAsyncLifetime
     WebApplication? _app;
 
     public HttpClient Client { get; private set; } = null!;
+    public IServiceProvider Services => _app!.Services;
 
     public async Task InitializeAsync()
     {
@@ -142,5 +145,27 @@ public class BundlingIntegrationTests(BundlingTestFixture fixture) : IClassFixtu
     {
         HttpResponseMessage response = await fixture.Client.GetAsync("/static.txt");
         Assert.Null(response.Headers.CacheControl);
+    }
+
+    [Fact]
+    public async Task StyleBundle_IntegrityHashMatchesServedContent()
+    {
+        HttpResponseMessage response = await fixture.Client.GetAsync("/bundles/css/site.min.css");
+        byte[] bytes = await response.Content.ReadAsByteArrayAsync();
+        string expected = "sha384-" + Convert.ToBase64String(SHA384.HashData(bytes));
+
+        StyleBundleProvider provider = fixture.Services.GetRequiredService<StyleBundleProvider>();
+        Assert.Equal(expected, provider.GetIntegrity("site"));
+    }
+
+    [Fact]
+    public async Task ScriptBundle_IntegrityHashMatchesServedContent()
+    {
+        HttpResponseMessage response = await fixture.Client.GetAsync("/bundles/js/app.min.js");
+        byte[] bytes = await response.Content.ReadAsByteArrayAsync();
+        string expected = "sha384-" + Convert.ToBase64String(SHA384.HashData(bytes));
+
+        ScriptBundleProvider provider = fixture.Services.GetRequiredService<ScriptBundleProvider>();
+        Assert.Equal(expected, provider.GetIntegrity("app"));
     }
 }

--- a/tests/DragonBundles.Tests/ScriptTagHelperTests.cs
+++ b/tests/DragonBundles.Tests/ScriptTagHelperTests.cs
@@ -78,4 +78,25 @@ public class ScriptTagHelperTests : IDisposable
         TagHelperOutput output = MakeTagHelper(Environments.Development, "app", "/js/a.js");
         Assert.Contains("data-bundle=\"app\"", output.Content.GetContent());
     }
+
+    [Fact]
+    public void Process_InProduction_EmitsIntegrityAndCrossoriginAttributes()
+    {
+        WriteJsFile("/js/a.js", "var x=1;");
+        TagHelperOutput output = MakeTagHelper(Environments.Production, "app", "/js/a.js");
+        string? html = output.Content.GetContent();
+
+        Assert.Contains("integrity=\"sha384-", html);
+        Assert.Contains("crossorigin=\"anonymous\"", html);
+    }
+
+    [Fact]
+    public void Process_InDevelopment_DoesNotEmitIntegrityAttributes()
+    {
+        TagHelperOutput output = MakeTagHelper(Environments.Development, "app", "/js/a.js", "/js/b.js");
+        string? html = output.Content.GetContent();
+
+        Assert.DoesNotContain("integrity=", html);
+        Assert.DoesNotContain("crossorigin=", html);
+    }
 }

--- a/tests/DragonBundles.Tests/StyleTagHelperTests.cs
+++ b/tests/DragonBundles.Tests/StyleTagHelperTests.cs
@@ -78,4 +78,25 @@ public class StyleTagHelperTests : IDisposable
         TagHelperOutput output = MakeTagHelper(Environments.Development, "site", "/css/a.css");
         Assert.Contains("data-bundle=\"site\"", output.Content.GetContent());
     }
+
+    [Fact]
+    public void Process_InProduction_EmitsIntegrityAndCrossoriginAttributes()
+    {
+        WriteCssFile("/css/a.css", "body { color: red; }");
+        TagHelperOutput output = MakeTagHelper(Environments.Production, "site", "/css/a.css");
+        string? html = output.Content.GetContent();
+
+        Assert.Contains("integrity=\"sha384-", html);
+        Assert.Contains("crossorigin=\"anonymous\"", html);
+    }
+
+    [Fact]
+    public void Process_InDevelopment_DoesNotEmitIntegrityAttributes()
+    {
+        TagHelperOutput output = MakeTagHelper(Environments.Development, "site", "/css/a.css", "/css/b.css");
+        string? html = output.Content.GetContent();
+
+        Assert.DoesNotContain("integrity=", html);
+        Assert.DoesNotContain("crossorigin=", html);
+    }
 }


### PR DESCRIPTION
Closes #27.

Tag helpers now stamp `integrity="sha384-..." crossorigin="anonymous"` on the production `<link>`/`<script>` so browsers can verify bundle bytes weren't tampered with in transit. The SHA-384 is computed once alongside the existing SHA-256 cache-busting hash, sharing the same UTF-8 byte buffer.

Dev mode (raw individual files) is unaffected — no integrity attrs emitted.