### PR TITLE
Use NuGet trusted publishing instead of API key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
 
     steps:
       - name: Generate App token
@@ -52,8 +55,14 @@ jobs:
       - name: Pack
         run: dotnet pack --no-build --configuration Release -p:ContinuousIntegrationBuild=true --output ./artifacts
 
+      - name: NuGet login (OIDC → temp API key)
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Push to NuGet
-        run: dotnet nuget push "./artifacts/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push "./artifacts/*.nupkg" --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
       - name: Create GitHub release
         env:


### PR DESCRIPTION
Closes #26.

Replaces the long-lived `NUGET_API_KEY` secret with OIDC-based trusted publishing. The release job now exchanges its GitHub-issued ID token for a 1-hour NuGet API key via `NuGet/login@v1` immediately before pushing the package.

Requires (one-time, before next release):
- Trusted publishing policy on nuget.org (owner `cadamsmith`, repo `dragon-bundles`, workflow file `release.yml`)
- New repo secret `NUGET_USER` set to the nuget.org profile name
- After the first successful publish, delete `NUGET_API_KEY` from repo secrets and revoke the key on nuget.org