### PR TITLE
Add SECURITY.md

### DIFF
--- a/DragonBundles.slnx
+++ b/DragonBundles.slnx
@@ -1,7 +1,10 @@
 <Solution>
   <Folder Name="/docs/">
     <File Path="CLAUDE.md" />
+    <File Path="CODE_OF_CONDUCT.md" />
+    <File Path="CONTRIBUTING.md" />
     <File Path="README.md" />
+    <File Path="SECURITY.md" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/DragonBundles/DragonBundles.csproj" />

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# 🐉 dragon-bundles: security policy
+
+## supported versions
+
+DragonBundles is pre-1.0. Only the latest published 0.x release receives security fixes; older versions are not patched.
+
+## reporting a vulnerability
+
+Please do not open a public issue for security problems.
+
+Use GitHub's [private vulnerability reporting](https://github.com/cadamsmith/dragon-bundles/security/advisories/new) to file a draft advisory. Include a description of the issue and its impact, the affected version(s), a minimal reproduction, and any suggested mitigation.
+
+Expect an initial response within 5 business days. If the report is confirmed, a fix and coordinated disclosure timeline are discussed in the advisory thread before any public disclosure.


### PR DESCRIPTION
Adds a security policy at the repo root so reporters have a clear, private channel for vulnerabilities instead of opening a public issue.

- Supported versions: latest published 0.x release (version-agnostic, no per-release maintenance)
- Reporting: GitHub private vulnerability reporting, with a 5-business-day initial response expectation