### PR TITLE
feat: emit source maps for minified JS bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,67 @@
 # 🐉 dragon-bundles
 
-CSS and JavaScript bundling and minification for ASP.NET Core and classic ASP.NET (System.Web).
+Modern CSS and JavaScript bundling and minification for **both** ASP.NET Core and classic ASP.NET (System.Web) — with one consistent API that makes migrating between them painless.
 
-In development, source files are served individually for easy debugging. In production, they are concatenated, minified via [NUglify](https://github.com/trullock/NUglify), and served as a single file.
+In development, source files are served individually for easy debugging. In production, they are concatenated, minified via [NUglify](https://github.com/trullock/NUglify), and served as a single fingerprinted file.
+
+## why dragon-bundles
+
+- **A migration bridge.** Bundle names and registration shape stay the same across .NET Framework and .NET Core. Modernize a legacy MVC5 app one step at a time without rewriting your view layer — swap the registration and rendering calls, keep the bundle names.
+- **Kills WebGrease on classic ASP.NET.** `System.Web.Optimization` still ships the abandoned WebGrease minifier, which struggles with modern CSS/JS. DragonBundles drops in [NUglify](https://github.com/trullock/NUglify) as a replacement with no other code changes.
+- **Secure by default.** Production bundles are emitted with a [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) hash and `crossorigin` attribute automatically.
+- **Zero build step, zero files on disk.** Bundles are built in-memory at startup and served through the pipeline. No node, no webpack, no generated artifacts to commit.
+- **Automatic cache busting and hot reload.** Content-hash `?v=` suffixes update whenever sources change, and source files are watched and re-minified without a restart.
 
 ## installation
 
 ```
 dotnet add package DragonBundles
 ```
+
+## migrating from system.web to asp.net core
+
+This is what DragonBundles is built for. Because bundle names are identical across both runtimes, upgrading is a mechanical swap rather than a rewrite:
+
+| | classic ASP.NET (net48) | ASP.NET Core (net10) |
+|---|---|---|
+| register | `bundles.AddStyleBundle("site", ...)` | `bundles.AddStyleBundle("site", ...)` |
+| render | `@Html.StyleBundle("site")` | `<style-bundle name="site">` |
+
+The bundle name (`"site"`) never changes, so your migration is confined to the registration and rendering calls — everything referencing bundles by name keeps working.
+
+## classic asp.net / system.web (.net framework 4.8)
+
+DragonBundles integrates with `System.Web.Optimization` as a drop-in upgrade, replacing the default WebGrease minifier with NUglify.
+
+### setup
+
+In `BundleConfig.cs`:
+
+```csharp
+using DragonBundles;
+
+public static void RegisterBundles(BundleCollection bundles)
+{
+    bundles.AddStyleBundle("site", "~/Content/base.css", "~/Content/layout.css");
+    bundles.AddScriptBundle("app", "~/Scripts/utils.js", "~/Scripts/app.js");
+}
+```
+
+### usage
+
+In Razor views, add `@using DragonBundles` (or add it to `Web.config`), then:
+
+```cshtml
+<head>
+    @Html.StyleBundle("site")
+</head>
+<body>
+    ...
+    @Html.ScriptBundle("app")
+</body>
+```
+
+Dev/prod rendering is controlled by `BundleTable.EnableOptimizations` — individual files in debug, single bundle in release, matching standard `System.Web.Optimization` behavior.
 
 ## asp.net core (.net 10)
 
@@ -62,6 +115,8 @@ In **Production**, a single minified bundle is rendered with a [Subresource Inte
 
 The `?v=...` suffix is a content hash for cache busting, updated automatically whenever source files change. The `integrity` attribute is a SHA-384 hash of the bundle bytes the browser uses to verify the response wasn't tampered with.
 
+Script bundles also emit a [source map](https://developer.mozilla.org/en-US/docs/Glossary/Source_map) (`app.min.js.map`) referenced from the minified file, so browser devtools resolve the minified bundle back to the original source files.
+
 Bundles are minified at startup and served in-memory — no files are written to disk. In non-Development environments, source files are watched for changes and re-minified automatically without a restart.
 
 Relative `url()` references in CSS files are rewritten to absolute paths before minification, so stylesheets from different directories compose correctly.
@@ -73,44 +128,6 @@ bundles.AddStyleBundle("site", "/css/**/*.css");
 ```
 
 Missing source files throw `FileNotFoundException` at startup.
-
-## classic asp.net / system.web (.net framework 4.8)
-
-DragonBundles integrates with `System.Web.Optimization` as a drop-in upgrade, replacing the default WebGrease minifier with NUglify.
-
-### setup
-
-In `BundleConfig.cs`:
-
-```csharp
-using DragonBundles;
-
-public static void RegisterBundles(BundleCollection bundles)
-{
-    bundles.AddStyleBundle("site", "~/Content/base.css", "~/Content/layout.css");
-    bundles.AddScriptBundle("app", "~/Scripts/utils.js", "~/Scripts/app.js");
-}
-```
-
-### usage
-
-In Razor views, add `@using DragonBundles` (or add it to `Web.config`), then:
-
-```cshtml
-<head>
-    @Html.StyleBundle("site")
-</head>
-<body>
-    ...
-    @Html.ScriptBundle("app")
-</body>
-```
-
-Dev/prod rendering is controlled by `BundleTable.EnableOptimizations` — individual files in debug, single bundle in release, matching standard `System.Web.Optimization` behavior.
-
-## migrating from system.web to asp.net core
-
-DragonBundles is designed to smooth this migration. Bundle names are consistent across both runtimes — swap the registration and rendering calls when you upgrade, and bundle names stay the same.
 
 ## requirements
 

--- a/src/DragonBundles/Bundle.cs
+++ b/src/DragonBundles/Bundle.cs
@@ -5,6 +5,7 @@ abstract class Bundle(string name, List<string> sourceFiles)
     public string Name { get; set; } = name;
     public List<string> SourceFiles { get; set; } = sourceFiles;
     public string MinifiedContent { get; set; } = string.Empty;
+    public string SourceMap { get; set; } = string.Empty;
     public string Version { get; set; } = string.Empty;
     public string Integrity { get; set; } = string.Empty;
     public DateTime LastModified { get; set; } = DateTime.UtcNow;

--- a/src/DragonBundles/BundleProvider.cs
+++ b/src/DragonBundles/BundleProvider.cs
@@ -128,9 +128,19 @@ abstract class BundleProvider<T>(IWebHostEnvironment env, string bundleDirectory
         }
 
         string name = subpath[bundleDirectory.Length..].Split('.')[0];
-        return _bundles.TryGetValue(name, out T? bundle)
-            ? new BundleFileInfo(bundle)
-            : new NotFoundFileInfo(subpath);
+        if (!_bundles.TryGetValue(name, out T? bundle))
+        {
+            return new NotFoundFileInfo(subpath);
+        }
+
+        if (subpath.EndsWith(".map", StringComparison.Ordinal))
+        {
+            return bundle.SourceMap.Length > 0
+                ? new BundleFileInfo(bundle.Name, bundle.SourceMap, bundle.LastModified)
+                : new NotFoundFileInfo(subpath);
+        }
+
+        return new BundleFileInfo(bundle.Name, bundle.MinifiedContent, bundle.LastModified);
     }
 
     public IDirectoryContents GetDirectoryContents(string subpath) =>
@@ -139,14 +149,14 @@ abstract class BundleProvider<T>(IWebHostEnvironment env, string bundleDirectory
     public IChangeToken Watch(string filter) =>
         NullChangeToken.Singleton;
 
-    sealed class BundleFileInfo(T bundle) : IFileInfo
+    sealed class BundleFileInfo(string name, string content, DateTimeOffset lastModified) : IFileInfo
     {
         public bool Exists => true;
         public bool IsDirectory => false;
-        public string Name => bundle.Name;
+        public string Name => name;
         public string? PhysicalPath => null;
-        public DateTimeOffset LastModified => bundle.LastModified;
-        public long Length => Encoding.UTF8.GetByteCount(bundle.MinifiedContent);
-        public Stream CreateReadStream() => new MemoryStream(Encoding.UTF8.GetBytes(bundle.MinifiedContent));
+        public DateTimeOffset LastModified => lastModified;
+        public long Length => Encoding.UTF8.GetByteCount(content);
+        public Stream CreateReadStream() => new MemoryStream(Encoding.UTF8.GetBytes(content));
     }
 }

--- a/src/DragonBundles/BundlingExtensions.cs
+++ b/src/DragonBundles/BundlingExtensions.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.StaticFiles;
+
 namespace DragonBundles;
 
 /// <summary>Extension methods for registering DragonBundles with ASP.NET Core.</summary>
@@ -23,12 +25,21 @@ public static class BundlingExtensions
 
         configure(new BundleConfigurator(styles, scripts));
 
+        FileExtensionContentTypeProvider contentTypeProvider = new();
+        contentTypeProvider.Mappings[".map"] = "application/json";
+
         app.UseStaticFiles(new StaticFileOptions
         {
             FileProvider = new CompositeFileProvider(styles, scripts, webEnv.WebRootFileProvider),
+            ContentTypeProvider = contentTypeProvider,
             OnPrepareResponse = ctx =>
             {
-                if (!webEnv.IsDevelopment() && ctx.Context.Request.Path.StartsWithSegments("/bundles"))
+                // Source maps are named after the bundle, not content-hashed, so they must not
+                // be cached immutably — the minified file they belong to is still fingerprinted.
+                bool isSourceMap = ctx.Context.Request.Path.Value?.EndsWith(".map", StringComparison.Ordinal) == true;
+                if (!webEnv.IsDevelopment()
+                    && ctx.Context.Request.Path.StartsWithSegments("/bundles")
+                    && !isSourceMap)
                 {
                     ctx.Context.Response.Headers.CacheControl = "public, max-age=31536000, immutable";
                 }

--- a/src/DragonBundles/DeferredSourceMap.cs
+++ b/src/DragonBundles/DeferredSourceMap.cs
@@ -1,0 +1,40 @@
+using NUglify.JavaScript;
+using NUglify.JavaScript.Syntax;
+
+namespace DragonBundles;
+
+/// <summary>
+/// Wraps NUglify's <see cref="V3SourceMap"/> so multiple source files can be minified into one
+/// bundle sharing a single map. <see cref="EndFile"/> is deliberately a no-op: otherwise each
+/// <c>Uglify.Js</c> call would emit its own <c>//# sourceMappingURL</c> comment mid-bundle,
+/// which corrupts the combined output's line offsets. The comment is appended once by the caller
+/// after the whole bundle is assembled.
+/// </summary>
+sealed class DeferredSourceMap(V3SourceMap inner) : ISourceMap
+{
+    public string Name => inner.Name;
+    public string SourceRoot { get => inner.SourceRoot; set => inner.SourceRoot = value; }
+    public bool SafeHeader { get => inner.SafeHeader; set => inner.SafeHeader = value; }
+
+    public void StartPackage(string sourcePath, string mapPath) => inner.StartPackage(sourcePath, mapPath);
+    public void EndPackage() => inner.EndPackage();
+
+    public object StartSymbol(AstNode node, int startLine, int startColumn) =>
+        inner.StartSymbol(node, startLine, startColumn);
+
+    public void MarkSegment(AstNode node, int startLine, int startColumn, string name, SourceContext context) =>
+        inner.MarkSegment(node, startLine, startColumn, name, context);
+
+    public void EndSymbol(object symbol, int endLine, int endColumn, string parentContext) =>
+        inner.EndSymbol(symbol, endLine, endColumn, parentContext);
+
+    public void EndOutputRun(int lineNumber, int columnPosition) =>
+        inner.EndOutputRun(lineNumber, columnPosition);
+
+    public void NewLineInsertedInOutput() => inner.NewLineInsertedInOutput();
+
+    // Deferred: suppress the per-file sourceMappingURL comment so combined offsets stay correct.
+    public void EndFile(TextWriter writer, string newLine) { }
+
+    public void Dispose() => inner.Dispose();
+}

--- a/src/DragonBundles/ScriptBundleProvider.cs
+++ b/src/DragonBundles/ScriptBundleProvider.cs
@@ -1,3 +1,5 @@
+using NUglify.JavaScript;
+
 namespace DragonBundles;
 
 sealed class ScriptBundleProvider(IWebHostEnvironment env) : BundleProvider<ScriptBundle>(env, "/bundles/js/")
@@ -8,13 +10,65 @@ sealed class ScriptBundleProvider(IWebHostEnvironment env) : BundleProvider<Scri
 
     public override void Minify(ScriptBundle bundle)
     {
-        bundle.MinifiedContent = string.Join(ConcatenationToken, bundle.SourceFiles.Select(f =>
+        string mapFileName = $"{bundle.Name}.min.js.map";
+
+        StringWriter mapWriter = new();
+        V3SourceMap inner = new(mapWriter) { MakePathsRelative = false };
+        DeferredSourceMap sourceMap = new(inner);
+        sourceMap.StartPackage($"{bundle.Name}.min.js", mapFileName);
+
+        CodeSettings settings = new() { SymbolsMap = sourceMap };
+
+        StringBuilder output = new();
+        bool hasMappings = false;
+        for (int i = 0; i < bundle.SourceFiles.Count; i++)
         {
-            string content = ReadSourceFile(bundle.Name, f);
-            return f.EndsWith(".min.js", StringComparison.OrdinalIgnoreCase)
-                ? content
-                : Uglify.Js(content).Code;
-        }));
+            string sourceUrl = bundle.SourceFiles[i];
+            string content = ReadSourceFile(bundle.Name, sourceUrl);
+
+            if (sourceUrl.EndsWith(".min.js", StringComparison.OrdinalIgnoreCase))
+            {
+                // Pre-minified: pass through verbatim (no mappings), but keep the map's output
+                // line counter aligned by notifying it of every newline we append.
+                output.Append(content);
+                NotifyNewLines(sourceMap, content);
+            }
+            else
+            {
+                output.Append(Uglify.Js(content, sourceUrl, settings).Code);
+                hasMappings = true;
+            }
+
+            if (i < bundle.SourceFiles.Count - 1)
+            {
+                output.Append(ConcatenationToken);
+                NotifyNewLines(sourceMap, ConcatenationToken);
+            }
+        }
+
+        sourceMap.EndPackage();
+        sourceMap.Dispose(); // flushes the map JSON to mapWriter
+
+        // Only attach a map when at least one file was actually minified; a bundle of only
+        // pre-minified files has no mappings and must pass through verbatim.
+        if (hasMappings)
+        {
+            output.Append(Environment.NewLine).Append("//# sourceMappingURL=").Append(mapFileName);
+            bundle.SourceMap = mapWriter.ToString();
+        }
+
+        bundle.MinifiedContent = output.ToString();
         bundle.LastModified = DateTime.UtcNow;
+    }
+
+    static void NotifyNewLines(DeferredSourceMap sourceMap, string text)
+    {
+        foreach (char c in text)
+        {
+            if (c == '\n')
+            {
+                sourceMap.NewLineInsertedInOutput();
+            }
+        }
     }
 }

--- a/tests/DragonBundles.Tests/BundlingIntegrationTests.cs
+++ b/tests/DragonBundles.Tests/BundlingIntegrationTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Security.Cryptography;
+using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
@@ -108,6 +109,40 @@ public class BundlingIntegrationTests(BundlingTestFixture fixture) : IClassFixtu
         string content = await response.Content.ReadAsStringAsync();
         Assert.Contains("hello", content);
         Assert.Contains("x=1", content);
+    }
+
+    [Fact]
+    public async Task ScriptBundle_SourceMap_IsServedAsJson()
+    {
+        HttpResponseMessage response = await fixture.Client.GetAsync("/bundles/js/app.min.js.map");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        string content = await response.Content.ReadAsStringAsync();
+        using JsonDocument doc = JsonDocument.Parse(content);
+        Assert.Equal(3, doc.RootElement.GetProperty("version").GetInt32());
+    }
+
+    [Fact]
+    public async Task ScriptBundle_Body_ReferencesSourceMap()
+    {
+        HttpResponseMessage response = await fixture.Client.GetAsync("/bundles/js/app.min.js");
+        string content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("//# sourceMappingURL=app.min.js.map", content);
+    }
+
+    [Fact]
+    public async Task ScriptBundle_SourceMap_IsNotCachedImmutable()
+    {
+        HttpResponseMessage response = await fixture.Client.GetAsync("/bundles/js/app.min.js.map");
+        Assert.DoesNotContain("immutable", response.Headers.CacheControl?.ToString() ?? string.Empty);
+    }
+
+    [Fact]
+    public async Task StyleBundle_HasNoSourceMap()
+    {
+        HttpResponseMessage response = await fixture.Client.GetAsync("/bundles/css/site.min.css.map");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     [Fact]

--- a/tests/DragonBundles.Tests/ScriptBundleProviderTests.cs
+++ b/tests/DragonBundles.Tests/ScriptBundleProviderTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text.Json;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.FileProviders;
 using NSubstitute;
@@ -200,6 +201,157 @@ public class ScriptBundleProviderTests : IDisposable
         Assert.True(posC >= 0);
         Assert.True(posA < posB && posB < posC);
         Assert.Contains("b=2", content);
+    }
+
+    static string ReadFileInfo(IFileInfo fileInfo)
+    {
+        using Stream stream = fileInfo.CreateReadStream();
+        return new StreamReader(stream).ReadToEnd();
+    }
+
+    [Fact]
+    public void Add_InProduction_AppendsSourceMappingUrlComment()
+    {
+        WriteJsFile("/js/app.js", "function hello() { return 'hi'; }");
+        ScriptBundleProvider provider = MakeProvider(Environments.Production);
+
+        provider.Add("app", "/js/app.js");
+
+        string content = ReadFileInfo(provider.GetFileInfo("/bundles/js/app.min.js"));
+        Assert.EndsWith("//# sourceMappingURL=app.min.js.map", content.TrimEnd());
+    }
+
+    [Fact]
+    public void Add_InProduction_ServesValidSourceMap()
+    {
+        WriteJsFile("/js/app.js", "function hello() { return 'hi'; }");
+        ScriptBundleProvider provider = MakeProvider(Environments.Production);
+
+        provider.Add("app", "/js/app.js");
+
+        IFileInfo mapInfo = provider.GetFileInfo("/bundles/js/app.min.js.map");
+        Assert.True(mapInfo.Exists);
+
+        using JsonDocument doc = JsonDocument.Parse(ReadFileInfo(mapInfo));
+        JsonElement root = doc.RootElement;
+        Assert.Equal(3, root.GetProperty("version").GetInt32());
+        Assert.NotEmpty(root.GetProperty("mappings").GetString()!);
+    }
+
+    [Fact]
+    public void Add_InProduction_MultiFile_SourceMapListsAllSources()
+    {
+        WriteJsFile("/js/a.js", "function alpha(name) { return 'hello ' + name; }");
+        WriteJsFile("/js/b.js", "function beta(x) { return x * 2; }");
+        ScriptBundleProvider provider = MakeProvider(Environments.Production);
+
+        provider.Add("app", "/js/a.js", "/js/b.js");
+
+        using JsonDocument doc = JsonDocument.Parse(ReadFileInfo(provider.GetFileInfo("/bundles/js/app.min.js.map")));
+        List<string> sources = [.. doc.RootElement.GetProperty("sources").EnumerateArray().Select(s => s.GetString()!)];
+        Assert.Contains("/js/a.js", sources);
+        Assert.Contains("/js/b.js", sources);
+    }
+
+    [Fact]
+    public void Add_InProduction_SourceMap_MapsEachFileToItsGeneratedLine()
+    {
+        // Guards the multi-file output-offset logic: top-level function names are preserved by
+        // NUglify, so each source's mappings must land on the generated line that actually
+        // contains that file's code. If the offset tracking regresses, file b collapses onto
+        // file a's line and this fails.
+        WriteJsFile("/js/a.js", "function alpha(name) { return 'hello ' + name; }");
+        WriteJsFile("/js/b.js", "function beta(x) { return x * 2; }");
+        ScriptBundleProvider provider = MakeProvider(Environments.Production);
+
+        provider.Add("app", "/js/a.js", "/js/b.js");
+
+        string[] generatedLines = ReadFileInfo(provider.GetFileInfo("/bundles/js/app.min.js")).Split('\n');
+        using JsonDocument doc = JsonDocument.Parse(ReadFileInfo(provider.GetFileInfo("/bundles/js/app.min.js.map")));
+        string[] sources = [.. doc.RootElement.GetProperty("sources").EnumerateArray().Select(s => s.GetString()!)];
+        List<Segment> segments = DecodeMappings(doc.RootElement.GetProperty("mappings").GetString()!);
+
+        Segment first = segments[0];
+        Assert.Equal(0, first.GenLine);
+        Assert.Equal(0, first.GenCol);
+        Assert.Equal("/js/a.js", sources[first.SrcIndex]);
+        Assert.Equal(0, first.SrcLine);
+
+        int aGenLine = segments.First(s => sources[s.SrcIndex] == "/js/a.js").GenLine;
+        int bGenLine = segments.First(s => sources[s.SrcIndex] == "/js/b.js").GenLine;
+        Assert.Contains("alpha", generatedLines[aGenLine]);
+        Assert.Contains("beta", generatedLines[bGenLine]);
+        Assert.True(aGenLine < bGenLine);
+    }
+
+    readonly record struct Segment(int GenLine, int GenCol, int SrcIndex, int SrcLine, int SrcCol);
+
+    // Decodes the VLQ `mappings` field into absolute segments that carry source references.
+    static List<Segment> DecodeMappings(string mappings)
+    {
+        List<Segment> result = [];
+        int genLine = 0, srcIndex = 0, srcLine = 0, srcCol = 0;
+        foreach (string lineGroup in mappings.Split(';'))
+        {
+            int genCol = 0;
+            foreach (string segment in lineGroup.Split(','))
+            {
+                if (segment.Length == 0)
+                {
+                    continue;
+                }
+
+                List<int> values = DecodeVlq(segment);
+                genCol += values[0];
+                if (values.Count >= 4)
+                {
+                    srcIndex += values[1];
+                    srcLine += values[2];
+                    srcCol += values[3];
+                    result.Add(new Segment(genLine, genCol, srcIndex, srcLine, srcCol));
+                }
+            }
+            genLine++;
+        }
+        return result;
+    }
+
+    static List<int> DecodeVlq(string segment)
+    {
+        const string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        List<int> result = [];
+        int shift = 0, value = 0;
+        foreach (char c in segment)
+        {
+            int digit = alphabet.IndexOf(c);
+            int continuation = digit & 32;
+            digit &= 31;
+            value += digit << shift;
+            if (continuation != 0)
+            {
+                shift += 5;
+            }
+            else
+            {
+                bool negative = (value & 1) == 1;
+                value >>= 1;
+                result.Add(negative ? -value : value);
+                value = 0;
+                shift = 0;
+            }
+        }
+        return result;
+    }
+
+    [Fact]
+    public void Add_InDevelopment_DoesNotGenerateSourceMap()
+    {
+        WriteJsFile("/js/app.js", "function hello() { return 'hi'; }");
+        ScriptBundleProvider provider = MakeProvider(Environments.Development);
+
+        provider.Add("app", "/js/app.js");
+
+        Assert.False(provider.GetFileInfo("/bundles/js/app.min.js.map").Exists);
     }
 
     [Fact]

--- a/tests/DragonBundles.Tests/StyleBundleProviderTests.cs
+++ b/tests/DragonBundles.Tests/StyleBundleProviderTests.cs
@@ -29,6 +29,17 @@ public class StyleBundleProviderTests : IDisposable
     }
 
     [Fact]
+    public void Add_InProduction_DoesNotGenerateSourceMap()
+    {
+        WriteCssFile("/css/site.css", "body { color: red; }");
+        StyleBundleProvider provider = MakeProvider(Environments.Production);
+
+        provider.Add("site", "/css/site.css");
+
+        Assert.False(provider.GetFileInfo("/bundles/css/site.min.css.map").Exists);
+    }
+
+    [Fact]
     public void Add_InProduction_MinifiesBundle()
     {
         WriteCssFile("/css/site.css", "body   {   color:   red;   }");


### PR DESCRIPTION
Closes #40.

Script bundles now emit a combined V3 source map so browser devtools resolve the minified bundle back to the original source files. This reaches parity with WebOptimizer and Smidge — both JS-only, since NUglify can't map CSS.

## What changed

- **`DeferredSourceMap`** wraps NUglify's `V3SourceMap` and no-ops `EndFile`, so `Uglify.Js` doesn't inject a per-file `sourceMappingURL` comment mid-bundle (which would corrupt the combined line offsets). Inter-file newlines are reported via `NewLineInsertedInOutput` to keep later files aligned.
- **`ScriptBundleProvider.Minify`** builds one map across all source files and appends `//# sourceMappingURL={name}.min.js.map`. Bundles of only pre-minified `.min.js` files still pass through verbatim (no map).
- The map is served at `/bundles/js/{name}.min.js.map` as `application/json`, and excluded from the `immutable` cache header (the filename isn't content-hashed, unlike the `?v=`-fingerprinted bundle).
- `StyleBundleProvider` is untouched — no CSS maps.
- README repositioned to lead with the System.Web→ASP.NET Core migration story, plus a note documenting source maps.

## Testing

- 80 tests pass, including a **VLQ-decoding correctness guard** that asserts each source file maps to the generated line actually containing its code (mutation-tested: it fails if the offset logic regresses).
- Manually verified in a real browser (Firefox): breakpoints set in the original `a.js`/`b.js` land on the correct lines with correct scope values.

## Follow-ups (not in this PR)

- #42 — bundle names containing a dot are parsed incorrectly (pre-existing).
