### PR TITLE
Add NUglify vs WebGrease minification benchmark

### DIFF
--- a/DragonBundles.slnx
+++ b/DragonBundles.slnx
@@ -1,4 +1,7 @@
 <Solution>
+  <Folder Name="/bench/">
+    <Project Path="bench/MinifyComparison/MinifyComparison.csproj" />
+  </Folder>
   <Folder Name="/docs/">
     <File Path="CLAUDE.md" />
     <File Path="CODE_OF_CONDUCT.md" />

--- a/DragonBundles.slnx
+++ b/DragonBundles.slnx
@@ -1,7 +1,4 @@
 <Solution>
-  <Folder Name="/bench/">
-    <Project Path="bench/MinifyComparison/MinifyComparison.csproj" />
-  </Folder>
   <Folder Name="/docs/">
     <File Path="CLAUDE.md" />
     <File Path="CODE_OF_CONDUCT.md" />

--- a/bench/MinifyComparison/MinifyComparison.csproj
+++ b/bench/MinifyComparison/MinifyComparison.csproj
@@ -3,7 +3,9 @@
   <!--
     Compares NUglify (what DragonBundles uses) against WebGrease's minifier
     (the engine System.Web.Optimization ships, via its bundled Microsoft.Ajax.Utilities).
-    A diagnostic tool, not shippable — IsPackable=false keeps it out of `dotnet pack`/release.
+    Standalone diagnostic: intentionally NOT in DragonBundles.slnx, so `dotnet build`/pack/CI
+    ignore it. Run it directly with `dotnet run` from this folder. IsPackable=false is a
+    safety net in case it is ever re-added to the solution.
     WebGrease is a .NET Framework package loaded via the net10 compatibility shim (NU1701).
   -->
   <PropertyGroup>

--- a/bench/MinifyComparison/MinifyComparison.csproj
+++ b/bench/MinifyComparison/MinifyComparison.csproj
@@ -3,7 +3,7 @@
   <!--
     Compares NUglify (what DragonBundles uses) against WebGrease's minifier
     (the engine System.Web.Optimization ships, via its bundled Microsoft.Ajax.Utilities).
-    Standalone: intentionally NOT part of DragonBundles.slnx, so `dotnet build`/CI ignore it.
+    A diagnostic tool, not shippable — IsPackable=false keeps it out of `dotnet pack`/release.
     WebGrease is a .NET Framework package loaded via the net10 compatibility shim (NU1701).
   -->
   <PropertyGroup>
@@ -13,6 +13,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <RollForward>LatestMajor</RollForward>
     <NoWarn>NU1701</NoWarn>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/bench/MinifyComparison/MinifyComparison.csproj
+++ b/bench/MinifyComparison/MinifyComparison.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Compares NUglify (what DragonBundles uses) against WebGrease's minifier
+    (the engine System.Web.Optimization ships, via its bundled Microsoft.Ajax.Utilities).
+    Standalone: intentionally NOT part of DragonBundles.slnx, so `dotnet build`/CI ignore it.
+    WebGrease is a .NET Framework package loaded via the net10 compatibility shim (NU1701).
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RollForward>LatestMajor</RollForward>
+    <NoWarn>NU1701</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUglify" Version="1.21.17" />
+    <PackageReference Include="WebGrease" Version="1.6.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="corpus\**\*" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/bench/MinifyComparison/Program.cs
+++ b/bench/MinifyComparison/Program.cs
@@ -1,0 +1,88 @@
+using System.Diagnostics;
+using Microsoft.Ajax.Utilities;
+using NUglify;
+
+// Compares NUglify (DragonBundles) vs WebGrease's minifier (System.Web.Optimization's engine)
+// on a corpus of classic and modern CSS/JS. Reports size reduction and — the headline — which
+// engine successfully parses modern (ES2020+ / modern CSS) syntax.
+
+const int timingRuns = 50;
+string corpus = Path.Combine(AppContext.BaseDirectory, "corpus");
+
+static string Cell(Result r)
+{
+    if (!r.Ok)
+    {
+        string reason = r.Errors < 0 ? "threw" : $"{r.Errors} err";
+        return $"FAILED ({reason})";
+    }
+    double reduction = r.Original == 0 ? 0 : 100.0 * (r.Original - r.Size) / r.Original;
+    return $"{r.Size,6} B  -{reduction,4:0.0}%  {r.Ms,6:0.00}ms";
+}
+
+Console.WriteLine();
+Console.WriteLine("NUglify (DragonBundles)  vs  WebGrease (System.Web.Optimization)");
+Console.WriteLine(new string('=', 78));
+Console.WriteLine($"{"file",-14}{"orig",7}   {"WebGrease",-26}{"NUglify",-26}");
+Console.WriteLine(new string('-', 78));
+
+foreach (string path in Directory.GetFiles(corpus).OrderBy(p => p))
+{
+    string name = Path.GetFileName(path);
+    bool isCss = name.EndsWith(".css", StringComparison.OrdinalIgnoreCase);
+    string source = File.ReadAllText(path);
+
+    Result wg = RunWebGrease(source, isCss);
+    Result nu = RunNUglify(source, isCss);
+
+    Console.WriteLine($"{name,-14}{source.Length,7}   {Cell(wg),-26}{Cell(nu),-26}");
+}
+
+Console.WriteLine(new string('-', 78));
+Console.WriteLine("size = minified bytes; -% = reduction vs original; ms = mean over " + timingRuns + " runs");
+Console.WriteLine("FAILED = engine could not parse the input (errors or exception).");
+Console.WriteLine();
+return;
+
+Result RunWebGrease(string source, bool isCss)
+{
+    Minifier minifier = new();
+    Stopwatch sw = Stopwatch.StartNew();
+    string output;
+    bool threw = false;
+    try
+    {
+        output = isCss ? minifier.MinifyStyleSheet(source) : minifier.MinifyJavaScript(source);
+    }
+    catch
+    {
+        threw = true;
+        output = string.Empty;
+    }
+    for (int i = 0; i < timingRuns && !threw; i++)
+    {
+        _ = isCss ? new Minifier().MinifyStyleSheet(source) : new Minifier().MinifyJavaScript(source);
+    }
+    sw.Stop();
+
+    int errors = minifier.ErrorList.Count;
+    bool ok = !threw && errors == 0 && !string.IsNullOrEmpty(output);
+    return new Result(source.Length, output?.Length ?? 0, ok, threw ? -1 : errors, sw.Elapsed.TotalMilliseconds / timingRuns);
+}
+
+Result RunNUglify(string source, bool isCss)
+{
+    Stopwatch sw = Stopwatch.StartNew();
+    UglifyResult result = isCss ? Uglify.Css(source) : Uglify.Js(source);
+    for (int i = 0; i < timingRuns; i++)
+    {
+        _ = isCss ? Uglify.Css(source) : Uglify.Js(source);
+    }
+    sw.Stop();
+
+    int errors = result.Errors?.Count ?? 0;
+    bool ok = !result.HasErrors && !string.IsNullOrEmpty(result.Code);
+    return new Result(source.Length, result.Code?.Length ?? 0, ok, errors, sw.Elapsed.TotalMilliseconds / timingRuns);
+}
+
+sealed record Result(int Original, int Size, bool Ok, int Errors, double Ms);

--- a/bench/MinifyComparison/README.md
+++ b/bench/MinifyComparison/README.md
@@ -1,0 +1,46 @@
+# MinifyComparison
+
+Compares **NUglify** (the minifier DragonBundles uses) against **WebGrease** (the minifier
+`System.Web.Optimization` ships and that DragonBundles replaces) on a corpus of classic and
+modern CSS/JS.
+
+This is a standalone diagnostic — it is intentionally **not** part of `DragonBundles.slnx`, so
+`dotnet build`/`dotnet test`/CI ignore it. WebGrease is a .NET Framework package; it loads on
+net10 via the compatibility shim (the `NU1701` warning is expected and suppressed). "WebGrease"
+here is its bundled `Microsoft.Ajax.Utilities` engine — the same engine `System.Web.Optimization`
+uses to minify.
+
+Versions: the harness pins **WebGrease 1.6.0** (the latest published). Note that
+`Microsoft.AspNet.Web.Optimization` 1.1.3 — the package DragonBundles' net48 target references —
+depends on **WebGrease 1.5.2**, so that's the version replaced in practice. Both fail identically
+on modern syntax, so the result below holds for either.
+
+## Run
+
+```bash
+cd bench/MinifyComparison
+dotnet run -c Release
+```
+
+## Result
+
+```
+file             orig   WebGrease                 NUglify
+------------------------------------------------------------------------------
+classic.css       195      113 B  -42.1%    0.51ms   106 B  -45.6%    0.43ms
+classic.js        319      184 B  -42.3%    0.66ms   184 B  -42.3%    0.72ms
+modern.css        352   FAILED (8 err)               275 B  -21.9%    0.09ms
+modern.js         465   FAILED (threw)               304 B  -34.6%    0.24ms
+```
+
+## Takeaway
+
+- On **classic** CSS/JS the two are neck-and-neck (NUglify is a fork of the same AjaxMin engine),
+  with NUglify a touch smaller on CSS.
+- On **modern** syntax WebGrease **fails outright** — it can't parse ES2020+ JS (private fields,
+  arrow functions, optional chaining `?.`, nullish `??`, spread) or modern CSS (custom properties,
+  `calc()`, `clamp()`, `:is()`, grid). NUglify handles all of it.
+
+That compatibility gap — not raw ratio — is why DragonBundles replaces WebGrease.
+
+The corpus lives in `corpus/`; add files there (`.css`/`.js`) to extend the comparison.

--- a/bench/MinifyComparison/corpus/classic.css
+++ b/bench/MinifyComparison/corpus/classic.css
@@ -1,0 +1,12 @@
+body {
+    color: #ffffff;
+    background-color: #ff0000;
+    margin: 0px 0px 0px 0px;
+    padding: 10px;
+}
+/* header styles */
+.header {
+    font-size: 16px;
+    font-weight: bold;
+}
+.empty { }

--- a/bench/MinifyComparison/corpus/classic.js
+++ b/bench/MinifyComparison/corpus/classic.js
@@ -1,0 +1,14 @@
+var Calculator = function () {
+    this.total = 0;
+};
+Calculator.prototype.add = function (value) {
+    this.total = this.total + value;
+    return this.total;
+};
+function sum(numbers) {
+    var result = 0;
+    for (var i = 0; i < numbers.length; i++) {
+        result = result + numbers[i];
+    }
+    return result;
+}

--- a/bench/MinifyComparison/corpus/modern.css
+++ b/bench/MinifyComparison/corpus/modern.css
@@ -1,0 +1,17 @@
+:root {
+    --primary: #3498db;
+    --gap: 16px;
+}
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: var(--gap);
+    padding: calc(var(--gap) * 2);
+}
+.title {
+    color: var(--primary);
+    font-size: clamp(1rem, 2.5vw, 2rem);
+}
+:is(.card, .panel):hover {
+    box-shadow: 0 0 0 2px var(--primary);
+}

--- a/bench/MinifyComparison/corpus/modern.js
+++ b/bench/MinifyComparison/corpus/modern.js
@@ -1,0 +1,15 @@
+class Calculator {
+    #total = 0;
+    add = (value) => {
+        this.#total += value;
+        return this.#total;
+    };
+}
+const sum = (...numbers) => numbers.reduce((acc, n) => acc + n, 0);
+const config = { timeout: 5000, retries: 3 };
+const timeout = config?.timeout ?? 1000;
+const greet = (name) => `Hello, ${name}! You have ${sum(1, 2, 3)} points.`;
+async function load(url) {
+    const res = await fetch(url);
+    return res?.ok ? await res.json() : null;
+}


### PR DESCRIPTION
Adds `bench/MinifyComparison`, a standalone harness that substantiates the README's "kills WebGrease" claim with numbers. It runs both minifiers over a corpus of classic and modern CSS/JS and reports size reduction, timing, and — the headline — which engine can parse the input.

It runs natively on any platform: WebGrease is a .NET Framework package, loaded on net10 via the compatibility shim (`NU1701`, suppressed). "WebGrease" here is its bundled `Microsoft.Ajax.Utilities` engine — the same one `System.Web.Optimization` uses.

## Result

```
file             orig   WebGrease                 NUglify
------------------------------------------------------------------------------
classic.css       195      113 B  -42.1%    0.54ms   106 B  -45.6%    0.37ms
classic.js        319      184 B  -42.3%    0.62ms   184 B  -42.3%    0.62ms
modern.css        352   FAILED (8 err)               275 B  -21.9%    0.09ms
modern.js         465   FAILED (threw)               304 B  -34.6%    0.24ms
```

- **Classic** CSS/JS: neck-and-neck (NUglify is a fork of the same AjaxMin engine), NUglify slightly smaller on CSS.
- **Modern** syntax: WebGrease fails outright on ES2020+ JS (private fields, arrow functions, `?.`, `??`, spread) and modern CSS (custom properties, `calc()`, `clamp()`, `:is()`, grid). NUglify handles all of it. That compatibility gap — not raw ratio — is why DragonBundles replaces WebGrease.

## Versions

Harness pins **WebGrease 1.6.0** (latest published). `Microsoft.AspNet.Web.Optimization` 1.1.3 — the package the net48 target references — pins **1.5.2**; both fail identically on modern syntax, so the result holds either way.

Extend the comparison by adding `.css`/`.js` files to `bench/MinifyComparison/corpus/`.
