### PR TITLE
Configurable NUglify settings (#41) and dotted bundle-name fix (#42)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,10 +22,11 @@ The two TFMs have entirely separate source files. `src/DragonBundles/` contains 
 
 ### public api surface — net10.0
 
-Only four types are public — everything else is `internal`:
+Only five types are public — everything else is `internal`:
 
 - `IBundleConfigurator` — fluent interface for registering bundles (`AddStyleBundle`, `AddScriptBundle`)
-- `BundlingExtensions` — `IServiceCollection.AddBundling()` and `IApplicationBuilder.UseBundling(Action<IBundleConfigurator>)`
+- `BundlingExtensions` — `IServiceCollection.AddBundling(Action<BundlingOptions>?)` and `IApplicationBuilder.UseBundling(Action<IBundleConfigurator>)`
+- `BundlingOptions` — global NUglify minification settings (`ScriptSettings` / `StyleSettings`), configured via `AddBundling`
 - `StyleTagHelper` — `<style-bundle name="...">` Razor tag helper
 - `ScriptTagHelper` — `<script-bundle name="...">` Razor tag helper
 
@@ -58,10 +59,11 @@ BundleConfigurator : IBundleConfigurator
 
 ### public api surface — net48
 
-Two types are public:
+Three types are public:
 
-- `BundleCollectionExtensions` — `BundleCollection.AddStyleBundle(name, files...)` and `AddScriptBundle(name, files...)`. Registers bundles at `~/bundles/css/{name}` and `~/bundles/js/{name}` with NUglify transforms.
+- `BundleCollectionExtensions` — `BundleCollection.AddStyleBundle(name, files...)` and `AddScriptBundle(name, files...)`, plus `ConfigureBundling(Action<BundlingOptions>)` for global NUglify settings (mirrors ASP.NET Core's `AddBundling`; options are held per-`BundleCollection` via a `ConditionalWeakTable` and read when bundles are registered). Registers bundles at `~/bundles/css/{name}` and `~/bundles/js/{name}` with NUglify transforms.
 - `HtmlHelperExtensions` — `@Html.StyleBundle(name)` and `@Html.ScriptBundle(name)`. Wraps `Styles.Render` / `Scripts.Render` with the internal virtual path.
+- `BundlingOptions` — shared, TFM-neutral minification settings type (also public on net10.0), configured here via `ConfigureBundling`.
 
 Two types are internal:
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ In Razor views, add `@using DragonBundles` (or add it to `Web.config`), then:
 
 Dev/prod rendering is controlled by `BundleTable.EnableOptimizations` — individual files in debug, single bundle in release, matching standard `System.Web.Optimization` behavior.
 
+To control NUglify's output, call `ConfigureBundling` before registering bundles — the same
+global model as ASP.NET Core's `AddBundling`:
+
+```csharp
+using NUglify.Css;
+
+bundles.ConfigureBundling(o =>
+{
+    o.ScriptSettings.PreserveImportantComments = true;
+    o.StyleSettings.CommentMode = CssComment.None;
+});
+```
+
 ## asp.net core (.net 10)
 
 ### setup
@@ -128,6 +141,21 @@ bundles.AddStyleBundle("site", "/css/**/*.css");
 ```
 
 Missing source files throw `FileNotFoundException` at startup.
+
+### configuring minification
+
+Pass a callback to `AddBundling` to control NUglify's minification of all bundles via
+[`CodeSettings`](https://github.com/trullock/NUglify) (scripts) and `CssSettings` (styles):
+
+```csharp
+using NUglify.Css;
+
+builder.Services.AddBundling(o =>
+{
+    o.ScriptSettings.PreserveImportantComments = true;
+    o.StyleSettings.CommentMode = CssComment.None;
+});
+```
 
 ## requirements
 

--- a/src/DragonBundles/BundleProvider.cs
+++ b/src/DragonBundles/BundleProvider.cs
@@ -127,13 +127,24 @@ abstract class BundleProvider<T>(IWebHostEnvironment env, string bundleDirectory
             return new NotFoundFileInfo(subpath);
         }
 
-        string name = subpath[bundleDirectory.Length..].Split('.')[0];
-        if (!_bundles.TryGetValue(name, out T? bundle))
+        // Requests are "{name}.min.{ext}" (the bundle) or "{name}.min.{ext}.map" (its source map).
+        // Strip the known suffix rather than splitting on '.', so names with dots (e.g. "jquery.ui")
+        // resolve correctly.
+        string fileName = subpath[bundleDirectory.Length..];
+        string bundleSuffix = $".min.{Extension}";
+        string mapSuffix = $"{bundleSuffix}.map";
+
+        bool isMap = fileName.EndsWith(mapSuffix, StringComparison.Ordinal);
+        string? name = isMap
+            ? fileName[..^mapSuffix.Length]
+            : fileName.EndsWith(bundleSuffix, StringComparison.Ordinal) ? fileName[..^bundleSuffix.Length] : null;
+
+        if (name is null || !_bundles.TryGetValue(name, out T? bundle))
         {
             return new NotFoundFileInfo(subpath);
         }
 
-        if (subpath.EndsWith(".map", StringComparison.Ordinal))
+        if (isMap)
         {
             return bundle.SourceMap.Length > 0
                 ? new BundleFileInfo(bundle.Name, bundle.SourceMap, bundle.LastModified)

--- a/src/DragonBundles/BundlingExtensions.cs
+++ b/src/DragonBundles/BundlingExtensions.cs
@@ -6,8 +6,14 @@ namespace DragonBundles;
 public static class BundlingExtensions
 {
     /// <summary>Registers DragonBundles services with the dependency injection container.</summary>
-    public static IServiceCollection AddBundling(this IServiceCollection services)
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Optional callback to configure minification settings (see <see cref="BundlingOptions"/>).</param>
+    public static IServiceCollection AddBundling(this IServiceCollection services, Action<BundlingOptions>? configure = null)
     {
+        BundlingOptions options = new();
+        configure?.Invoke(options);
+
+        services.AddSingleton(options);
         services.AddSingleton<StyleBundleProvider>();
         services.AddSingleton<ScriptBundleProvider>();
         return services;

--- a/src/DragonBundles/BundlingOptions.cs
+++ b/src/DragonBundles/BundlingOptions.cs
@@ -1,0 +1,17 @@
+using NUglify.Css;
+using NUglify.JavaScript;
+
+namespace DragonBundles;
+
+/// <summary>
+/// Global NUglify minification settings for bundles. On ASP.NET Core, configure via
+/// <c>AddBundling</c>; on classic ASP.NET, via <c>BundleCollection.ConfigureBundling</c>.
+/// </summary>
+public sealed class BundlingOptions
+{
+    /// <summary>NUglify settings applied when minifying script bundles.</summary>
+    public CodeSettings ScriptSettings { get; set; } = new();
+
+    /// <summary>NUglify settings applied when minifying style bundles.</summary>
+    public CssSettings StyleSettings { get; set; } = new();
+}

--- a/src/DragonBundles/DragonBundles.csproj
+++ b/src/DragonBundles/DragonBundles.csproj
@@ -33,10 +33,11 @@
     <Compile Remove="SystemWeb\**\*.cs" />
   </ItemGroup>
 
-  <!-- net48: exclude all core files, include only SystemWeb files -->
+  <!-- net48: exclude all core files, include only SystemWeb files (plus shared, TFM-neutral types) -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <Compile Remove="**\*.cs" />
     <Compile Include="SystemWeb\**\*.cs" />
+    <Compile Include="BundlingOptions.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">

--- a/src/DragonBundles/ScriptBundleProvider.cs
+++ b/src/DragonBundles/ScriptBundleProvider.cs
@@ -2,7 +2,7 @@ using NUglify.JavaScript;
 
 namespace DragonBundles;
 
-sealed class ScriptBundleProvider(IWebHostEnvironment env) : BundleProvider<ScriptBundle>(env, "/bundles/js/")
+sealed class ScriptBundleProvider(IWebHostEnvironment env, BundlingOptions options) : BundleProvider<ScriptBundle>(env, "/bundles/js/")
 {
     protected override string Extension => "js";
     protected override string ConcatenationToken => ";" + Environment.NewLine;
@@ -17,7 +17,8 @@ sealed class ScriptBundleProvider(IWebHostEnvironment env) : BundleProvider<Scri
         DeferredSourceMap sourceMap = new(inner);
         sourceMap.StartPackage($"{bundle.Name}.min.js", mapFileName);
 
-        CodeSettings settings = new() { SymbolsMap = sourceMap };
+        CodeSettings settings = options.ScriptSettings.Clone();
+        settings.SymbolsMap = sourceMap;
 
         StringBuilder output = new();
         bool hasMappings = false;

--- a/src/DragonBundles/StyleBundleProvider.cs
+++ b/src/DragonBundles/StyleBundleProvider.cs
@@ -1,6 +1,6 @@
 namespace DragonBundles;
 
-sealed partial class StyleBundleProvider(IWebHostEnvironment env) : BundleProvider<StyleBundle>(env, "/bundles/css/")
+sealed partial class StyleBundleProvider(IWebHostEnvironment env, BundlingOptions options) : BundleProvider<StyleBundle>(env, "/bundles/css/")
 {
     [GeneratedRegex(@"url\(\s*(['""]?)([^'""\)\s]+)\1\s*\)")]
     private static partial Regex UrlPattern();
@@ -15,7 +15,7 @@ sealed partial class StyleBundleProvider(IWebHostEnvironment env) : BundleProvid
             string content = ReadSourceFile(bundle.Name, f);
             return f.EndsWith(".min.css", StringComparison.OrdinalIgnoreCase)
                 ? content
-                : Uglify.Css(content).Code;
+                : Uglify.Css(content, options.StyleSettings).Code;
         }));
         bundle.LastModified = DateTime.UtcNow;
     }

--- a/src/DragonBundles/SystemWeb/BundleCollectionExtensions.cs
+++ b/src/DragonBundles/SystemWeb/BundleCollectionExtensions.cs
@@ -1,10 +1,25 @@
+using System.Runtime.CompilerServices;
+
 namespace DragonBundles;
 
 /// <summary>Extension methods for registering DragonBundles with <c>System.Web.Optimization</c>.</summary>
 public static class BundleCollectionExtensions
 {
+    // Options are associated with a specific BundleCollection instance rather than held statically,
+    // so configuration doesn't leak across collections (mirrors the per-container options on
+    // ASP.NET Core). Configure before registering bundles.
+    static readonly ConditionalWeakTable<BundleCollection, BundlingOptions> _optionsTable = new();
+
     extension(BundleCollection bundles)
     {
+        /// <summary>Configures NUglify minification settings applied to all bundles registered on this collection.</summary>
+        /// <param name="configure">Callback to configure <see cref="BundlingOptions"/>.</param>
+        public BundleCollection ConfigureBundling(Action<BundlingOptions> configure)
+        {
+            configure(_optionsTable.GetOrCreateValue(bundles));
+            return bundles;
+        }
+
         /// <summary>Registers a CSS bundle using NUglify minification.</summary>
         /// <param name="name">Bundle name. Served at <c>~/bundles/css/{name}</c>.</param>
         /// <param name="files">Source file virtual paths (e.g. <c>~/Content/site.css</c>).</param>
@@ -12,7 +27,7 @@ public static class BundleCollectionExtensions
         {
             StyleBundle bundle = new($"~/bundles/css/{name}");
             bundle.Transforms.Clear();
-            bundle.Transforms.Add(new NUglifyStyleTransform());
+            bundle.Transforms.Add(new NUglifyStyleTransform(_optionsTable.GetOrCreateValue(bundles).StyleSettings));
             foreach (string file in files)
             {
                 bundle.Include(file, new CssRewriteUrlTransform());
@@ -29,7 +44,7 @@ public static class BundleCollectionExtensions
         {
             ScriptBundle bundle = new($"~/bundles/js/{name}");
             bundle.Transforms.Clear();
-            bundle.Transforms.Add(new NUglifyScriptTransform());
+            bundle.Transforms.Add(new NUglifyScriptTransform(_optionsTable.GetOrCreateValue(bundles).ScriptSettings));
             foreach (string file in files)
             {
                 bundle.Include(file);

--- a/src/DragonBundles/SystemWeb/GlobalUsings.cs
+++ b/src/DragonBundles/SystemWeb/GlobalUsings.cs
@@ -2,3 +2,5 @@ global using System.Web;
 global using System.Web.Mvc;
 global using System.Web.Optimization;
 global using NUglify;
+global using NUglify.Css;
+global using NUglify.JavaScript;

--- a/src/DragonBundles/SystemWeb/NUglifyScriptTransform.cs
+++ b/src/DragonBundles/SystemWeb/NUglifyScriptTransform.cs
@@ -1,10 +1,12 @@
 namespace DragonBundles;
 
-sealed class NUglifyScriptTransform : IBundleTransform
+sealed class NUglifyScriptTransform(CodeSettings? settings = null) : IBundleTransform
 {
+    readonly CodeSettings _settings = settings ?? new CodeSettings();
+
     public void Process(BundleContext context, BundleResponse response)
     {
-        response.Content = Uglify.Js(response.Content).Code;
+        response.Content = Uglify.Js(response.Content, _settings).Code;
         response.ContentType = "text/javascript";
     }
 }

--- a/src/DragonBundles/SystemWeb/NUglifyStyleTransform.cs
+++ b/src/DragonBundles/SystemWeb/NUglifyStyleTransform.cs
@@ -1,10 +1,12 @@
 namespace DragonBundles;
 
-sealed class NUglifyStyleTransform : IBundleTransform
+sealed class NUglifyStyleTransform(CssSettings? settings = null) : IBundleTransform
 {
+    readonly CssSettings _settings = settings ?? new CssSettings();
+
     public void Process(BundleContext context, BundleResponse response)
     {
-        response.Content = Uglify.Css(response.Content).Code;
+        response.Content = Uglify.Css(response.Content, _settings).Code;
         response.ContentType = "text/css";
     }
 }

--- a/tests/DragonBundles.Tests/BundlingIntegrationTests.cs
+++ b/tests/DragonBundles.Tests/BundlingIntegrationTests.cs
@@ -146,6 +146,38 @@ public class BundlingIntegrationTests(BundlingTestFixture fixture) : IClassFixtu
     }
 
     [Fact]
+    public async Task AddBundling_AppliesConfiguredScriptSettings_EndToEnd()
+    {
+        string webRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(webRoot);
+        Directory.CreateDirectory(Path.Combine(webRoot, "js"));
+        File.WriteAllText(Path.Combine(webRoot, "js", "app.js"), "/*! license */\nfunction f() { return 1; }");
+
+        WebApplicationBuilder builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Production,
+            WebRootPath = webRoot,
+        });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddBundling(o => o.ScriptSettings.PreserveImportantComments = true);
+
+        await using WebApplication app = builder.Build();
+        app.UseBundling(bundles => bundles.AddScriptBundle("app", "/js/app.js"));
+        await app.StartAsync();
+
+        try
+        {
+            using HttpClient client = app.GetTestClient();
+            string content = await client.GetStringAsync("/bundles/js/app.min.js");
+            Assert.Contains("/*! license */", content);
+        }
+        finally
+        {
+            Directory.Delete(webRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task StaticFile_IsStillServedViaCompositeProvider()
     {
         HttpResponseMessage response = await fixture.Client.GetAsync("/static.txt");

--- a/tests/DragonBundles.Tests/ScriptBundleProviderTests.cs
+++ b/tests/DragonBundles.Tests/ScriptBundleProviderTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.FileProviders;
 using NSubstitute;
+using NUglify.JavaScript;
 
 namespace DragonBundles.Tests;
 
@@ -13,13 +14,13 @@ public class ScriptBundleProviderTests : IDisposable
     public ScriptBundleProviderTests() => Directory.CreateDirectory(_webRoot);
     public void Dispose() => Directory.Delete(_webRoot, recursive: true);
 
-    ScriptBundleProvider MakeProvider(string envName)
+    ScriptBundleProvider MakeProvider(string envName, BundlingOptions? options = null)
     {
         IWebHostEnvironment? env = Substitute.For<IWebHostEnvironment>();
         env.EnvironmentName.Returns(envName);
         env.WebRootPath.Returns(_webRoot);
         env.WebRootFileProvider.Returns(new NullFileProvider());
-        return new ScriptBundleProvider(env);
+        return new ScriptBundleProvider(env, options ?? new BundlingOptions());
     }
 
     void WriteJsFile(string relativePath, string content)
@@ -207,6 +208,54 @@ public class ScriptBundleProviderTests : IDisposable
     {
         using Stream stream = fileInfo.CreateReadStream();
         return new StreamReader(stream).ReadToEnd();
+    }
+
+    [Fact]
+    public void Add_InProduction_PreservesImportantComments_WhenScriptSettingEnabled()
+    {
+        WriteJsFile("/js/app.js", "/*! license */\nfunction f() { return 1; }");
+        BundlingOptions options = new();
+        options.ScriptSettings.PreserveImportantComments = true;
+        ScriptBundleProvider provider = MakeProvider(Environments.Production, options);
+
+        provider.Add("app", "/js/app.js");
+
+        Assert.Contains("/*! license */", ReadFileInfo(provider.GetFileInfo("/bundles/js/app.min.js")));
+    }
+
+    [Fact]
+    public void Add_InProduction_StripsImportantComments_WhenScriptSettingDisabled()
+    {
+        WriteJsFile("/js/app.js", "/*! license */\nfunction f() { return 1; }");
+        BundlingOptions options = new();
+        options.ScriptSettings.PreserveImportantComments = false;
+        ScriptBundleProvider provider = MakeProvider(Environments.Production, options);
+
+        provider.Add("app", "/js/app.js");
+
+        Assert.DoesNotContain("/*! license */", ReadFileInfo(provider.GetFileInfo("/bundles/js/app.min.js")));
+    }
+
+    [Fact]
+    public void GetFileInfo_ResolvesBundleNameContainingDot()
+    {
+        WriteJsFile("/js/jquery.ui.js", "var x = 1;");
+        ScriptBundleProvider provider = MakeProvider(Environments.Production);
+
+        provider.Add("jquery.ui", "/js/jquery.ui.js");
+
+        Assert.True(provider.GetFileInfo("/bundles/js/jquery.ui.min.js").Exists);
+        Assert.True(provider.GetFileInfo("/bundles/js/jquery.ui.min.js.map").Exists);
+    }
+
+    [Fact]
+    public void GetFileInfo_ReturnsNotFound_ForUnrecognizedSuffix()
+    {
+        WriteJsFile("/js/app.js", "var x = 1;");
+        ScriptBundleProvider provider = MakeProvider(Environments.Production);
+        provider.Add("app", "/js/app.js");
+
+        Assert.False(provider.GetFileInfo("/bundles/js/app.js").Exists);
     }
 
     [Fact]
@@ -410,7 +459,7 @@ public class ScriptBundleProviderTests : IDisposable
         env.WebRootPath.Returns(_webRoot);
         env.WebRootFileProvider.Returns(fileProvider);
 
-        ScriptBundleProvider provider = new(env);
+        ScriptBundleProvider provider = new(env, new BundlingOptions());
         provider.Add("app", "/js/app.js");
 
         IFileInfo initial = provider.GetFileInfo("/bundles/js/app.min.js");

--- a/tests/DragonBundles.Tests/ScriptTagHelperTests.cs
+++ b/tests/DragonBundles.Tests/ScriptTagHelperTests.cs
@@ -25,7 +25,7 @@ public class ScriptTagHelperTests : IDisposable
         env.EnvironmentName.Returns(envName);
         env.WebRootPath.Returns(_webRoot);
 
-        ScriptBundleProvider provider = new(env);
+        ScriptBundleProvider provider = new(env, new BundlingOptions());
         if (sourceFiles.Length > 0)
         {
             provider.Add(bundleName, sourceFiles);

--- a/tests/DragonBundles.Tests/StyleBundleProviderTests.cs
+++ b/tests/DragonBundles.Tests/StyleBundleProviderTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.FileProviders;
 using NSubstitute;
+using NUglify.Css;
 
 namespace DragonBundles.Tests;
 
@@ -12,13 +13,13 @@ public class StyleBundleProviderTests : IDisposable
     public StyleBundleProviderTests() => Directory.CreateDirectory(_webRoot);
     public void Dispose() => Directory.Delete(_webRoot, recursive: true);
 
-    StyleBundleProvider MakeProvider(string envName)
+    StyleBundleProvider MakeProvider(string envName, BundlingOptions? options = null)
     {
         IWebHostEnvironment? env = Substitute.For<IWebHostEnvironment>();
         env.EnvironmentName.Returns(envName);
         env.WebRootPath.Returns(_webRoot);
         env.WebRootFileProvider.Returns(new NullFileProvider());
-        return new StyleBundleProvider(env);
+        return new StyleBundleProvider(env, options ?? new BundlingOptions());
     }
 
     void WriteCssFile(string relativePath, string content)
@@ -26,6 +27,49 @@ public class StyleBundleProviderTests : IDisposable
         string full = Path.Combine(_webRoot, relativePath.TrimStart('/'));
         Directory.CreateDirectory(Path.GetDirectoryName(full)!);
         File.WriteAllText(full, content);
+    }
+
+    static string ReadFileInfo(IFileInfo fileInfo)
+    {
+        using Stream stream = fileInfo.CreateReadStream();
+        return new StreamReader(stream).ReadToEnd();
+    }
+
+    [Fact]
+    public void Add_InProduction_PreservesImportantComments_WhenStyleSettingIsImportant()
+    {
+        WriteCssFile("/css/site.css", "/*! brand */\n.x { color: red; }");
+        BundlingOptions options = new();
+        options.StyleSettings.CommentMode = CssComment.Important;
+        StyleBundleProvider provider = MakeProvider(Environments.Production, options);
+
+        provider.Add("site", "/css/site.css");
+
+        Assert.Contains("/*! brand */", ReadFileInfo(provider.GetFileInfo("/bundles/css/site.min.css")));
+    }
+
+    [Fact]
+    public void Add_InProduction_StripsComments_WhenStyleSettingIsNone()
+    {
+        WriteCssFile("/css/site.css", "/*! brand */\n.x { color: red; }");
+        BundlingOptions options = new();
+        options.StyleSettings.CommentMode = CssComment.None;
+        StyleBundleProvider provider = MakeProvider(Environments.Production, options);
+
+        provider.Add("site", "/css/site.css");
+
+        Assert.DoesNotContain("/*! brand */", ReadFileInfo(provider.GetFileInfo("/bundles/css/site.min.css")));
+    }
+
+    [Fact]
+    public void GetFileInfo_ResolvesBundleNameContainingDot()
+    {
+        WriteCssFile("/css/bootstrap.grid.css", ".x { color: red; }");
+        StyleBundleProvider provider = MakeProvider(Environments.Production);
+
+        provider.Add("bootstrap.grid", "/css/bootstrap.grid.css");
+
+        Assert.True(provider.GetFileInfo("/bundles/css/bootstrap.grid.min.css").Exists);
     }
 
     [Fact]
@@ -360,7 +404,7 @@ public class StyleBundleProviderTests : IDisposable
         env.WebRootPath.Returns(_webRoot);
         env.WebRootFileProvider.Returns(fileProvider);
 
-        StyleBundleProvider provider = new(env);
+        StyleBundleProvider provider = new(env, new BundlingOptions());
         provider.Add("site", "/css/site.css");
 
         IFileInfo initial = provider.GetFileInfo("/bundles/css/site.min.css");

--- a/tests/DragonBundles.Tests/StyleTagHelperTests.cs
+++ b/tests/DragonBundles.Tests/StyleTagHelperTests.cs
@@ -25,7 +25,7 @@ public class StyleTagHelperTests : IDisposable
         env.EnvironmentName.Returns(envName);
         env.WebRootPath.Returns(_webRoot);
 
-        StyleBundleProvider provider = new(env);
+        StyleBundleProvider provider = new(env, new BundlingOptions());
         if (sourceFiles.Length > 0)
         {
             provider.Add(bundleName, sourceFiles);

--- a/tests/DragonBundles.Tests/SystemWeb/BundleCollectionExtensionsTests.cs
+++ b/tests/DragonBundles.Tests/SystemWeb/BundleCollectionExtensionsTests.cs
@@ -110,14 +110,19 @@ public class BundleCollectionExtensionsTests
     [Fact]
     public void ConfigureBundling_DoesNotLeakAcrossCollections()
     {
-        BundleCollection configured = MakeBundles();
-        configured.ConfigureBundling(o => o.ScriptSettings.PreserveImportantComments = true);
+        // Configure two collections with opposite settings; each must keep its own.
+        const string source = "/*! license */\nfunction f() { return 1; }";
 
-        BundleCollection other = MakeBundles();
-        other.AddScriptBundle("app", "~/Scripts/app.js");
+        BundleCollection keeps = MakeBundles();
+        keeps.ConfigureBundling(o => o.ScriptSettings.PreserveImportantComments = true);
+        keeps.AddScriptBundle("app", "~/Scripts/app.js");
 
-        string output = RunTransform(other.GetBundleFor("~/bundles/js/app")!, "/*! license */\nfunction f() { return 1; }");
-        Assert.DoesNotContain("/*! license */", output);
+        BundleCollection strips = MakeBundles();
+        strips.ConfigureBundling(o => o.ScriptSettings.PreserveImportantComments = false);
+        strips.AddScriptBundle("app", "~/Scripts/app.js");
+
+        Assert.Contains("/*! license */", RunTransform(keeps.GetBundleFor("~/bundles/js/app")!, source));
+        Assert.DoesNotContain("/*! license */", RunTransform(strips.GetBundleFor("~/bundles/js/app")!, source));
     }
 
     [Fact]

--- a/tests/DragonBundles.Tests/SystemWeb/BundleCollectionExtensionsTests.cs
+++ b/tests/DragonBundles.Tests/SystemWeb/BundleCollectionExtensionsTests.cs
@@ -1,4 +1,6 @@
 using System.Web.Optimization;
+using NUglify.Css;
+using NUglify.JavaScript;
 
 namespace DragonBundles.Tests.SystemWeb;
 
@@ -72,6 +74,60 @@ public class BundleCollectionExtensionsTests
 
         Bundle bundle = bundles.GetBundleFor("~/bundles/js/app");
         Assert.IsType<ScriptBundle>(bundle);
+    }
+
+    static string RunTransform(Bundle bundle, string content)
+    {
+        BundleResponse response = new() { Content = content };
+        ((IBundleTransform)bundle.Transforms.Single()).Process(null!, response);
+        return response.Content;
+    }
+
+    [Fact]
+    public void ConfigureBundling_AppliesStyleSettingsToRegisteredBundle()
+    {
+        BundleCollection bundles = MakeBundles();
+
+        bundles.ConfigureBundling(o => o.StyleSettings.CommentMode = CssComment.None);
+        bundles.AddStyleBundle("css", "~/Content/site.css");
+
+        string output = RunTransform(bundles.GetBundleFor("~/bundles/css/css")!, "/*! brand */\n.x { color: red; }");
+        Assert.DoesNotContain("/*! brand */", output);
+    }
+
+    [Fact]
+    public void ConfigureBundling_AppliesScriptSettingsToRegisteredBundle()
+    {
+        BundleCollection bundles = MakeBundles();
+
+        bundles.ConfigureBundling(o => o.ScriptSettings.PreserveImportantComments = true);
+        bundles.AddScriptBundle("app", "~/Scripts/app.js");
+
+        string output = RunTransform(bundles.GetBundleFor("~/bundles/js/app")!, "/*! license */\nfunction f() { return 1; }");
+        Assert.Contains("/*! license */", output);
+    }
+
+    [Fact]
+    public void ConfigureBundling_DoesNotLeakAcrossCollections()
+    {
+        BundleCollection configured = MakeBundles();
+        configured.ConfigureBundling(o => o.ScriptSettings.PreserveImportantComments = true);
+
+        BundleCollection other = MakeBundles();
+        other.AddScriptBundle("app", "~/Scripts/app.js");
+
+        string output = RunTransform(other.GetBundleFor("~/bundles/js/app")!, "/*! license */\nfunction f() { return 1; }");
+        Assert.DoesNotContain("/*! license */", output);
+    }
+
+    [Fact]
+    public void ConfigureBundling_ReturnsSameBundleCollection()
+    {
+        BundleCollection bundles = MakeBundles();
+
+        BundleCollection result = bundles.ConfigureBundling(o => o.ScriptSettings.TermSemicolons = true);
+
+        Assert.Same(bundles, result);
     }
 
     [Fact]

--- a/tests/DragonBundles.Tests/SystemWeb/NUglifyTransformTests.cs
+++ b/tests/DragonBundles.Tests/SystemWeb/NUglifyTransformTests.cs
@@ -1,4 +1,6 @@
 using System.Web.Optimization;
+using NUglify.Css;
+using NUglify.JavaScript;
 
 namespace DragonBundles.Tests.SystemWeb;
 
@@ -37,6 +39,30 @@ public class NUglifyTransformTests
 
         Exception? ex = Record.Exception(() => transform.Process(null!, response));
         Assert.Null(ex);
+    }
+
+    [Fact]
+    public void NUglifyStyleTransform_Process_HonorsCssSettings()
+    {
+        BundleResponse kept = MakeResponse("/*! brand */\n.x { color: red; }");
+        new NUglifyStyleTransform(new CssSettings { CommentMode = CssComment.Important }).Process(null!, kept);
+        Assert.Contains("/*! brand */", kept.Content);
+
+        BundleResponse stripped = MakeResponse("/*! brand */\n.x { color: red; }");
+        new NUglifyStyleTransform(new CssSettings { CommentMode = CssComment.None }).Process(null!, stripped);
+        Assert.DoesNotContain("/*! brand */", stripped.Content);
+    }
+
+    [Fact]
+    public void NUglifyScriptTransform_Process_HonorsCodeSettings()
+    {
+        BundleResponse kept = MakeResponse("/*! license */\nfunction f() { return 1; }");
+        new NUglifyScriptTransform(new CodeSettings { PreserveImportantComments = true }).Process(null!, kept);
+        Assert.Contains("/*! license */", kept.Content);
+
+        BundleResponse stripped = MakeResponse("/*! license */\nfunction f() { return 1; }");
+        new NUglifyScriptTransform(new CodeSettings { PreserveImportantComments = false }).Process(null!, stripped);
+        Assert.DoesNotContain("/*! license */", stripped.Content);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #41. Closes #42.

## #41 — configurable NUglify settings (both runtimes, consistent model)

`BundlingOptions` (`ScriptSettings` / `StyleSettings`) is now a shared, TFM-neutral public type. Minification output was previously fixed; you can now control it via the same global model on both runtimes:

```csharp
// ASP.NET Core (net10)
builder.Services.AddBundling(o => o.ScriptSettings.PreserveImportantComments = true);

// classic ASP.NET (net48)
bundles.ConfigureBundling(o => o.ScriptSettings.PreserveImportantComments = true);
```

- **net10:** options are injected into the providers; the JS path clones them and sets `SymbolsMap` so source maps still work.
- **net48:** `ConfigureBundling` stores options per `BundleCollection` (via `ConditionalWeakTable`, so nothing leaks across collections), read when bundles are registered and threaded into the transforms. This mirrors net10's global model rather than per-bundle settings.

## #42 — dotted bundle names

`BundleProvider.GetFileInfo` now strips the known `.min.{ext}[.map]` suffix instead of splitting on the first `.`, so a bundle named `jquery.ui` resolves correctly. Unrecognized suffixes return NotFound.

## Tests

- net10: 88 passing, including settings (both directions), dotted-name resolution, and an end-to-end `AddBundling` config test.
- net48 (compile-verified locally, runs on the Windows CI runner): transform-level settings tests plus `ConfigureBundling` tests, including a cross-collection no-leak test.

## Notes

- Docs updated (README shows both `AddBundling` and `ConfigureBundling`; CLAUDE.md public-type counts and net48 API).
- Remaining net48 parity gaps (SRI, JS source maps) are tracked separately in #45 and #46.
