### PR TITLE
Multi-target net8.0 (#39)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: |
+            8.0.x
+            10.0.x
 
       - name: Restore
         run: dotnet restore
@@ -27,7 +29,10 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --configuration Release -p:ContinuousIntegrationBuild=true
 
-      - name: Test
+      - name: Test (net8.0)
+        run: dotnet test --no-build --configuration Release --framework net8.0
+
+      - name: Test (net10.0)
         run: dotnet test --no-build --configuration Release --framework net10.0
 
       - name: Pack
@@ -42,7 +47,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: |
+            8.0.x
+            10.0.x
 
       - name: Restore
         run: dotnet restore

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            tfm: net8.0
+          - os: ubuntu-latest
             tfm: net10.0
           - os: windows-latest
             tfm: net48
@@ -32,7 +34,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: |
+            8.0.x
+            10.0.x
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: |
+            8.0.x
+            10.0.x
 
       - name: Bump version in csproj
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,10 @@ dotnet pack                                         # produce the NuGet .nupkg
 
 DragonBundles is a multi-targeted NuGet library supporting two runtimes:
 
-- **`net10.0`** — ASP.NET Core. Bundles CSS/JS at startup and serves them through static file middleware via a custom `IFileProvider`.
+- **`net8.0` / `net10.0`** — ASP.NET Core. Bundles CSS/JS at startup and serves them through static file middleware via a custom `IFileProvider`. Both TFMs compile from the same source.
 - **`net48`** — Classic ASP.NET (System.Web). Integrates with `System.Web.Optimization` as a drop-in, replacing WebGrease with NUglify.
 
-The two TFMs have entirely separate source files. `src/DragonBundles/` contains the net10.0 implementation; `src/DragonBundles/SystemWeb/` contains the net48 implementation. MSBuild ItemGroup conditions in the `.csproj` select the right set per TFM.
+The runtimes have entirely separate source files. `src/DragonBundles/` contains the ASP.NET Core implementation (net8.0 + net10.0); `src/DragonBundles/SystemWeb/` contains the net48 implementation. MSBuild ItemGroup conditions in the `.csproj` select the right set per TFM.
 
 ### public api surface — net10.0
 
@@ -83,7 +83,7 @@ JS files are separated by `;\n` before concatenation (`ScriptBundleProvider.Conc
 
 ### tests
 
-Tests live in `tests/DragonBundles.Tests/`. Internal types are exposed via `InternalsVisibleTo`. The project also multi-targets `net10.0;net48` using the same conditional compile pattern as the main library.
+Tests live in `tests/DragonBundles.Tests/`. Internal types are exposed via `InternalsVisibleTo`. The project also multi-targets `net8.0;net10.0;net48` using the same conditional compile pattern as the main library.
 
 **net10.0 tests** (root of `tests/DragonBundles.Tests/`):
 - `StyleBundleProviderTests` / `ScriptBundleProviderTests` — provider logic. Tests that write files use a per-test temp directory cleaned up via `IDisposable`.
@@ -98,4 +98,4 @@ net48 tests compile on Mac but only run on Windows. CI runs them on a `windows-l
 
 ### target frameworks
 
-`net10.0;net48`. ASP.NET Core types come from `<FrameworkReference Include="Microsoft.AspNetCore.App" />` (net10.0 only). System.Web types come from `Microsoft.AspNet.Web.Optimization` and `Microsoft.AspNet.Mvc` NuGet packages (net48 only). `Microsoft.NETFramework.ReferenceAssemblies` enables cross-compilation of the net48 target on Mac.
+`net8.0;net10.0;net48`. The ASP.NET Core implementation compiles for both `net8.0` and `net10.0` from the same source; ASP.NET Core types come from the versionless `<FrameworkReference Include="Microsoft.AspNetCore.App" />` (net8.0 + net10.0). System.Web types come from `Microsoft.AspNet.Web.Optimization` and `Microsoft.AspNet.Mvc` NuGet packages (net48 only). `Microsoft.NETFramework.ReferenceAssemblies` enables cross-compilation of the net48 target on Mac.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ dotnet add package DragonBundles
 
 This is what DragonBundles is built for. Because bundle names are identical across both runtimes, upgrading is a mechanical swap rather than a rewrite:
 
-| | classic ASP.NET (net48) | ASP.NET Core (net10) |
+| | classic ASP.NET (net48) | ASP.NET Core (net8 / net10) |
 |---|---|---|
 | register | `bundles.AddStyleBundle("site", ...)` | `bundles.AddStyleBundle("site", ...)` |
 | render | `@Html.StyleBundle("site")` | `<style-bundle name="site">` |
@@ -76,7 +76,7 @@ bundles.ConfigureBundling(o =>
 });
 ```
 
-## asp.net core (.net 10)
+## asp.net core (.net 8 / .net 10)
 
 ### setup
 
@@ -161,5 +161,6 @@ builder.Services.AddBundling(o =>
 
 | Target | Runtime |
 |---|---|
+| `net8.0` | .NET 8, ASP.NET Core |
 | `net10.0` | .NET 10, ASP.NET Core |
 | `net48` | .NET Framework 4.8, ASP.NET MVC 5 |

--- a/src/DragonBundles/BundleProvider.cs
+++ b/src/DragonBundles/BundleProvider.cs
@@ -8,7 +8,7 @@ abstract class BundleProvider<T>(IWebHostEnvironment env, string bundleDirectory
     readonly IFileProvider _webRootFileProvider = env.WebRootFileProvider;
     protected readonly string WebRootPath = env.WebRootPath;
 
-    readonly Lock _rebuildLock = new();
+    readonly object _rebuildLock = new();
 
     protected abstract string Extension { get; }
     protected virtual string ConcatenationToken => Environment.NewLine;

--- a/src/DragonBundles/DragonBundles.csproj
+++ b/src/DragonBundles/DragonBundles.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0;net48</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -40,7 +40,7 @@
     <Compile Include="BundlingOptions.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/tests/DragonBundles.Tests/DragonBundles.Tests.csproj
+++ b/tests/DragonBundles.Tests/DragonBundles.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0;net48</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -27,8 +27,15 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.20" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
   </ItemGroup>
 


### PR DESCRIPTION
Adds `net8.0` alongside `net10.0` for the ASP.NET Core target so net8 LTS apps can reference the package. The ASP.NET Core implementation compiles unchanged for both TFMs from the same source.

The only source-level blocker was `System.Threading.Lock` (.NET 9+), used for the rebuild lock in `BundleProvider`; swapped it for a plain `object` lock that works on all TFMs.

- **csproj** — add `net8.0` to `TargetFrameworks`; broaden the versionless `Microsoft.AspNetCore.App` FrameworkReference to net8.0 + net10.0.
- **tests** — add `net8.0`; pin `Microsoft.AspNetCore.TestHost` 8.0.20 for net8 (net10 stays on 10.0.7).
- **CI** — build/test net8.0, install the 8.0.x SDK across all workflows, add a net8.0 CodeQL matrix entry.
- **docs** — note net8.0 support in README and CLAUDE.md.

Verified locally: net8.0 and net10.0 both build and pass all 89 tests; `dotnet pack` emits `lib/net8.0`, `lib/net10.0`, and `lib/net48`; format check clean.

Closes #39.
