### PR TITLE
Emit JS source maps on classic ASP.NET (net48) bundles (#46)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,10 +65,12 @@ Three types are public:
 - `HtmlHelperExtensions` — `@Html.StyleBundle(name)` and `@Html.ScriptBundle(name)`. Wraps `Styles.Render` / `Scripts.Render` with the internal virtual path.
 - `BundlingOptions` — shared, TFM-neutral minification settings type (also public on net10.0), configured here via `ConfigureBundling`.
 
-Two types are internal:
+Internal types:
 
 - `NUglifyStyleTransform : IBundleTransform` — replaces WebGrease's `CssMinify`
-- `NUglifyScriptTransform : IBundleTransform` — replaces WebGrease's `JsMinify`
+- `NUglifyScriptTransform : IBundleTransform` — replaces WebGrease's `JsMinify`; also generates the JS source map (see below)
+- `SourceMapStore` — static in-memory map of bundle name → generated source-map JSON
+- `SourceMapHandler : IHttpHandler` / `SourceMapRouteHandler : IRouteHandler` — serve the stored map at `bundles/js/{name}.min.js.map`
 
 ### minification
 
@@ -81,6 +83,13 @@ CSS files are preprocessed by `StyleBundleProvider.TransformFileContent()` befor
 
 JS files are separated by `;\n` before concatenation (`ScriptBundleProvider.ConcatenationToken`) to guard against ASI hazards at file boundaries.
 
+### JS source maps
+
+Script bundles emit a V3 source map plus a trailing `//# sourceMappingURL={name}.min.js.map` comment on both TFMs. The map-generation logic (per-file minify loop, pre-minified passthrough with output-line tracking, single trailing `sourceMappingURL`) lives in the TFM-neutral `ScriptMapMinifier.Minify(...)`, sharing `DeferredSourceMap` — both files are compiled into the net48 target via explicit `Compile Include` (like `BundlingOptions.cs`).
+
+- net10.0: `ScriptBundleProvider.Minify()` builds `(sourceUrl, content)` pairs from `env.WebRootPath` and calls the helper; the map is stored on `bundle.SourceMap` and served in-memory at `{name}.min.js.map`.
+- net48: `NUglifyScriptTransform` rebuilds the pairs from `BundleResponse.Files` (via `BundleFile.ApplyTransforms()` + `IncludedVirtualPath`) — the transform is handed already-concatenated content, so per-file info must come from `Files` — calls the helper, and stashes the map in the static in-memory `SourceMapStore` keyed by bundle name. `AddScriptBundle` registers one `System.Web.Routing.Route` (inserted at index 0, once) mapping `bundles/js/{name}.min.js.map` to `SourceMapHandler`, which serves the stored map as `application/json` with non-immutable caching. When `BundleResponse.Files` is unavailable (e.g. a unit test setting `Content` directly), the transform falls back to minifying the combined content with no map.
+
 ### tests
 
 Tests live in `tests/DragonBundles.Tests/`. Internal types are exposed via `InternalsVisibleTo`. The project also multi-targets `net8.0;net10.0;net48` using the same conditional compile pattern as the main library.
@@ -89,9 +98,10 @@ Tests live in `tests/DragonBundles.Tests/`. Internal types are exposed via `Inte
 - `StyleBundleProviderTests` / `ScriptBundleProviderTests` — provider logic. Tests that write files use a per-test temp directory cleaned up via `IDisposable`.
 - `StyleTagHelperTests` / `ScriptTagHelperTests` — tag helper HTML output in dev vs production. Use real `TagHelperContext`/`TagHelperOutput` — no mocking needed.
 - `BundlingIntegrationTests` — end-to-end HTTP tests using `TestServer` via `BundlingTestFixture` (`IClassFixture`). Verifies bundles are served at the correct URLs with correct content types and minified content; also confirms static files still pass through the `CompositeFileProvider`.
+- `ScriptMapMinifierTests` — host-independent contract for the shared `ScriptMapMinifier` (sourceMappingURL append, per-source listing, pre-minified passthrough, no-map when all inputs are pre-minified). Primary local guard for source-map behavior on both TFMs since the net48 transform's map path only runs on a live host.
 
 **net48 tests** (`tests/DragonBundles.Tests/SystemWeb/`):
-- `NUglifyTransformTests` — `IBundleTransform` implementations. Uses a real `BundleResponse` with `null` context (transforms don't access context).
+- `NUglifyTransformTests` — `IBundleTransform` implementations (these hit the `Files == null` fallback, so the map path is covered by `ScriptMapMinifierTests`, not here) plus `SourceMapStore` round-trip. Uses a real `BundleResponse` with `null` context (transforms don't access context).
 - `BundleCollectionExtensionsTests` — verifies virtual path registration and NUglify transform wiring via `GetBundleFor()`. Uses a fresh `new BundleCollection()` per test (never `BundleTable.Bundles`).
 
 net48 tests compile on Mac but only run on Windows. CI runs them on a `windows-latest` GitHub Actions runner.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ In Razor views, add `@using DragonBundles` (or add it to `Web.config`), then:
 
 Dev/prod rendering is controlled by `BundleTable.EnableOptimizations` — individual files in debug, single bundle in release, matching standard `System.Web.Optimization` behavior.
 
+Script bundles emit a [source map](https://developer.mozilla.org/en-US/docs/Glossary/Source_map) referenced from the minified file (`//# sourceMappingURL={name}.min.js.map`) and served at `~/bundles/js/{name}.min.js.map`, so browser devtools resolve the bundle back to the original source files — parity with the ASP.NET Core target. `AddScriptBundle` registers the route that serves it, so no extra wiring is needed.
+
 To control NUglify's output, call `ConfigureBundling` before registering bundles — the same
 global model as ASP.NET Core's `AddBundling`:
 

--- a/src/DragonBundles/DragonBundles.csproj
+++ b/src/DragonBundles/DragonBundles.csproj
@@ -38,6 +38,9 @@
     <Compile Remove="**\*.cs" />
     <Compile Include="SystemWeb\**\*.cs" />
     <Compile Include="BundlingOptions.cs" />
+    <!-- TFM-neutral source-map helpers shared with the ASP.NET Core target -->
+    <Compile Include="ScriptMapMinifier.cs" />
+    <Compile Include="DeferredSourceMap.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">

--- a/src/DragonBundles/ScriptBundleProvider.cs
+++ b/src/DragonBundles/ScriptBundleProvider.cs
@@ -1,5 +1,3 @@
-using NUglify.JavaScript;
-
 namespace DragonBundles;
 
 sealed class ScriptBundleProvider(IWebHostEnvironment env, BundlingOptions options) : BundleProvider<ScriptBundle>(env, "/bundles/js/")
@@ -10,66 +8,18 @@ sealed class ScriptBundleProvider(IWebHostEnvironment env, BundlingOptions optio
 
     public override void Minify(ScriptBundle bundle)
     {
-        string mapFileName = $"{bundle.Name}.min.js.map";
+        List<(string, string)> files =
+            [.. bundle.SourceFiles.Select(sourceUrl => (sourceUrl, ReadSourceFile(bundle.Name, sourceUrl)))];
 
-        StringWriter mapWriter = new();
-        V3SourceMap inner = new(mapWriter) { MakePathsRelative = false };
-        DeferredSourceMap sourceMap = new(inner);
-        sourceMap.StartPackage($"{bundle.Name}.min.js", mapFileName);
+        (string content, string? map) =
+            ScriptMapMinifier.Minify(bundle.Name, files, options.ScriptSettings, ConcatenationToken);
 
-        CodeSettings settings = options.ScriptSettings.Clone();
-        settings.SymbolsMap = sourceMap;
-
-        StringBuilder output = new();
-        bool hasMappings = false;
-        for (int i = 0; i < bundle.SourceFiles.Count; i++)
+        bundle.MinifiedContent = content;
+        if (map is not null)
         {
-            string sourceUrl = bundle.SourceFiles[i];
-            string content = ReadSourceFile(bundle.Name, sourceUrl);
-
-            if (sourceUrl.EndsWith(".min.js", StringComparison.OrdinalIgnoreCase))
-            {
-                // Pre-minified: pass through verbatim (no mappings), but keep the map's output
-                // line counter aligned by notifying it of every newline we append.
-                output.Append(content);
-                NotifyNewLines(sourceMap, content);
-            }
-            else
-            {
-                output.Append(Uglify.Js(content, sourceUrl, settings).Code);
-                hasMappings = true;
-            }
-
-            if (i < bundle.SourceFiles.Count - 1)
-            {
-                output.Append(ConcatenationToken);
-                NotifyNewLines(sourceMap, ConcatenationToken);
-            }
+            bundle.SourceMap = map;
         }
 
-        sourceMap.EndPackage();
-        sourceMap.Dispose(); // flushes the map JSON to mapWriter
-
-        // Only attach a map when at least one file was actually minified; a bundle of only
-        // pre-minified files has no mappings and must pass through verbatim.
-        if (hasMappings)
-        {
-            output.Append(Environment.NewLine).Append("//# sourceMappingURL=").Append(mapFileName);
-            bundle.SourceMap = mapWriter.ToString();
-        }
-
-        bundle.MinifiedContent = output.ToString();
         bundle.LastModified = DateTime.UtcNow;
-    }
-
-    static void NotifyNewLines(DeferredSourceMap sourceMap, string text)
-    {
-        foreach (char c in text)
-        {
-            if (c == '\n')
-            {
-                sourceMap.NewLineInsertedInOutput();
-            }
-        }
     }
 }

--- a/src/DragonBundles/ScriptMapMinifier.cs
+++ b/src/DragonBundles/ScriptMapMinifier.cs
@@ -1,0 +1,93 @@
+using System.Text;
+using NUglify;
+using NUglify.JavaScript;
+
+namespace DragonBundles;
+
+/// <summary>
+/// Minifies an ordered set of JavaScript source files into a single bundle sharing one V3 source
+/// map. TFM-neutral so both the ASP.NET Core provider (startup minification) and the classic
+/// ASP.NET <c>IBundleTransform</c> (request-time minification) produce byte-identical output.
+/// Pre-minified <c>.min.js</c> inputs pass through verbatim while the map's output-line counter is
+/// kept aligned, so their offsets stay correct in the combined bundle.
+/// </summary>
+static class ScriptMapMinifier
+{
+    /// <summary>
+    /// Minifies <paramref name="files"/> (in order) into one bundle.
+    /// </summary>
+    /// <returns>
+    /// The minified bundle content — with a trailing <c>//# sourceMappingURL={name}.min.js.map</c>
+    /// comment when at least one file produced mappings — and the map JSON, or <c>null</c> when no
+    /// file was minified (a bundle of only pre-minified files carries no map).
+    /// </returns>
+    public static (string Content, string? Map) Minify(
+        string bundleName,
+        IReadOnlyList<(string SourceUrl, string Content)> files,
+        CodeSettings settings,
+        string concatenationToken)
+    {
+        string mapFileName = $"{bundleName}.min.js.map";
+
+        StringWriter mapWriter = new();
+        V3SourceMap inner = new(mapWriter) { MakePathsRelative = false };
+        DeferredSourceMap sourceMap = new(inner);
+        sourceMap.StartPackage($"{bundleName}.min.js", mapFileName);
+
+        CodeSettings mapSettings = settings.Clone();
+        mapSettings.SymbolsMap = sourceMap;
+
+        StringBuilder output = new();
+        bool hasMappings = false;
+        for (int i = 0; i < files.Count; i++)
+        {
+            string sourceUrl = files[i].SourceUrl;
+            string content = files[i].Content;
+
+            if (sourceUrl.EndsWith(".min.js", StringComparison.OrdinalIgnoreCase))
+            {
+                // Pre-minified: pass through verbatim (no mappings), but keep the map's output
+                // line counter aligned by notifying it of every newline we append.
+                output.Append(content);
+                NotifyNewLines(sourceMap, content);
+            }
+            else
+            {
+                output.Append(Uglify.Js(content, sourceUrl, mapSettings).Code);
+                hasMappings = true;
+            }
+
+            if (i < files.Count - 1)
+            {
+                output.Append(concatenationToken);
+                NotifyNewLines(sourceMap, concatenationToken);
+            }
+        }
+
+        sourceMap.EndPackage();
+        sourceMap.Dispose(); // flushes the map JSON to mapWriter
+
+        // Only attach a map when at least one file was actually minified; a bundle of only
+        // pre-minified files has no mappings and must pass through verbatim.
+        string result = output.ToString();
+        string? map = null;
+        if (hasMappings)
+        {
+            result += Environment.NewLine + "//# sourceMappingURL=" + mapFileName;
+            map = mapWriter.ToString();
+        }
+
+        return (result, map);
+    }
+
+    static void NotifyNewLines(DeferredSourceMap sourceMap, string text)
+    {
+        foreach (char c in text)
+        {
+            if (c == '\n')
+            {
+                sourceMap.NewLineInsertedInOutput();
+            }
+        }
+    }
+}

--- a/src/DragonBundles/SystemWeb/BundleCollectionExtensions.cs
+++ b/src/DragonBundles/SystemWeb/BundleCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Web.Routing;
 
 namespace DragonBundles;
 
@@ -44,14 +45,36 @@ public static class BundleCollectionExtensions
         {
             ScriptBundle bundle = new($"~/bundles/js/{name}");
             bundle.Transforms.Clear();
-            bundle.Transforms.Add(new NUglifyScriptTransform(_optionsTable.GetOrCreateValue(bundles).ScriptSettings));
+            bundle.Transforms.Add(new NUglifyScriptTransform(name, _optionsTable.GetOrCreateValue(bundles).ScriptSettings));
             foreach (string file in files)
             {
                 bundle.Include(file);
             }
 
             bundles.Add(bundle);
+            EnsureSourceMapRoute();
             return bundles;
+        }
+    }
+
+    // 0 until the source-map route has been registered, 1 afterwards.
+    static int _sourceMapRouteRegistered;
+
+    // Registers a single route that serves every JS bundle's source map at
+    // `bundles/js/{name}.min.js.map` — the path the browser resolves from the bundle's
+    // `//# sourceMappingURL={name}.min.js.map` comment. Inserted at index 0 so it is matched before
+    // a catch-all MVC route (which would otherwise bind it as controller=bundles/action=js).
+    static void EnsureSourceMapRoute()
+    {
+        if (Interlocked.CompareExchange(ref _sourceMapRouteRegistered, 1, 0) != 0)
+        {
+            return;
+        }
+
+        Route route = new("bundles/js/{name}.min.js.map", new SourceMapRouteHandler());
+        using (RouteTable.Routes.GetWriteLock())
+        {
+            RouteTable.Routes.Insert(0, route);
         }
     }
 }

--- a/src/DragonBundles/SystemWeb/NUglifyScriptTransform.cs
+++ b/src/DragonBundles/SystemWeb/NUglifyScriptTransform.cs
@@ -1,12 +1,57 @@
 namespace DragonBundles;
 
-sealed class NUglifyScriptTransform(CodeSettings? settings = null) : IBundleTransform
+sealed class NUglifyScriptTransform(string bundleName, CodeSettings? settings = null) : IBundleTransform
 {
+    // Match the ASP.NET Core target's ASI-safe token so both runtimes concatenate identically.
+    static readonly string _concatenationToken = ";" + Environment.NewLine;
+
     readonly CodeSettings _settings = settings ?? new CodeSettings();
 
     public void Process(BundleContext context, BundleResponse response)
     {
-        response.Content = Uglify.Js(response.Content, _settings).Code;
+        List<(string, string)>? files = ReadFiles(response);
+
+        if (files is null || files.Count == 0)
+        {
+            // No per-file information available (e.g. a unit test that sets Content directly with
+            // no Files). Minify the already-concatenated content; there is nothing to map.
+            response.Content = Uglify.Js(response.Content, _settings).Code;
+        }
+        else
+        {
+            (string content, string? map) =
+                ScriptMapMinifier.Minify(bundleName, files, _settings, _concatenationToken);
+
+            response.Content = content;
+            if (map is not null)
+            {
+                SourceMapStore.Set(bundleName, map);
+            }
+        }
+
         response.ContentType = "text/javascript";
+    }
+
+    // Re-reads each included file (applying any item transforms) alongside its virtual path, so the
+    // bundle can be re-minified per file with source-map offsets — System.Web hands the transform
+    // the already-concatenated blob, which has lost the file boundaries a map needs.
+    static List<(string, string)>? ReadFiles(BundleResponse response)
+    {
+        if (response.Files is null)
+        {
+            return null;
+        }
+
+        List<(string, string)> files = [];
+        foreach (BundleFile file in response.Files)
+        {
+            // IncludedVirtualPath is app-relative (e.g. "~/Scripts/app.js"); "~" is meaningless to a
+            // browser, so make it web-absolute ("/Scripts/app.js") — matching the ASP.NET Core map's
+            // source style — so devtools can actually fetch the original file from static content.
+            string sourceUrl = VirtualPathUtility.ToAbsolute(file.IncludedVirtualPath);
+            files.Add((sourceUrl, file.ApplyTransforms()));
+        }
+
+        return files;
     }
 }

--- a/src/DragonBundles/SystemWeb/SourceMapHandler.cs
+++ b/src/DragonBundles/SystemWeb/SourceMapHandler.cs
@@ -1,0 +1,43 @@
+using System.Web.Routing;
+
+namespace DragonBundles;
+
+/// <summary>
+/// Serves a JS bundle's source map from <see cref="SourceMapStore"/> as <c>application/json</c>.
+/// System.Web.Optimization owns the <c>~/bundles/js/{name}</c> path and has no slot for a companion
+/// artifact, so the map is served through a dedicated route (registered by
+/// <c>AddScriptBundle</c>) rather than the bundle handler.
+/// </summary>
+sealed class SourceMapHandler(string bundleName) : IHttpHandler
+{
+    // Carries the per-request bundle name, so a fresh instance is created per request.
+    public bool IsReusable => false;
+
+    public void ProcessRequest(HttpContext context)
+    {
+        if (SourceMapStore.TryGet(bundleName, out string map))
+        {
+            context.Response.ContentType = "application/json";
+            // Map is served at a stable name (not content-hashed), so avoid immutable caching —
+            // mirrors how the ASP.NET Core target skips the immutable header for .map files.
+            context.Response.Cache.SetCacheability(HttpCacheability.NoCache);
+            context.Response.Write(map);
+        }
+        else
+        {
+            context.Response.StatusCode = 404;
+        }
+    }
+}
+
+/// <summary>
+/// Route handler that extracts the <c>{name}</c> token and hands off to a <see cref="SourceMapHandler"/>.
+/// </summary>
+sealed class SourceMapRouteHandler : IRouteHandler
+{
+    public IHttpHandler GetHttpHandler(RequestContext requestContext)
+    {
+        string bundleName = requestContext.RouteData.Values["name"] as string ?? string.Empty;
+        return new SourceMapHandler(bundleName);
+    }
+}

--- a/src/DragonBundles/SystemWeb/SourceMapStore.cs
+++ b/src/DragonBundles/SystemWeb/SourceMapStore.cs
@@ -1,0 +1,20 @@
+using System.Collections.Concurrent;
+
+namespace DragonBundles;
+
+/// <summary>
+/// Holds the most recently generated JS source map for each bundle, keyed by bundle name.
+/// The request-time <see cref="NUglifyScriptTransform"/> writes here whenever it minifies; the
+/// <see cref="SourceMapHandler"/> route reads from here. Kept in memory (no disk) to match the
+/// ASP.NET Core target. A map is written before the browser can learn its URL (which only appears
+/// in the <c>sourceMappingURL</c> comment of the already-served bundle), so a lookup can never
+/// race ahead of the store.
+/// </summary>
+static class SourceMapStore
+{
+    static readonly ConcurrentDictionary<string, string> _maps = new(StringComparer.Ordinal);
+
+    public static void Set(string bundleName, string map) => _maps[bundleName] = map;
+
+    public static bool TryGet(string bundleName, out string map) => _maps.TryGetValue(bundleName, out map);
+}

--- a/tests/DragonBundles.Tests/DragonBundles.Tests.csproj
+++ b/tests/DragonBundles.Tests/DragonBundles.Tests.csproj
@@ -43,6 +43,7 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNet.Web.Optimization" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
+    <Reference Include="System.Web" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/DragonBundles.Tests/ScriptMapMinifierTests.cs
+++ b/tests/DragonBundles.Tests/ScriptMapMinifierTests.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+using NUglify.JavaScript;
+
+namespace DragonBundles.Tests;
+
+// Locks the TFM-neutral contract of the shared minify/map helper. The classic ASP.NET transform
+// relies on this exact behaviour but can only exercise it on a live host (Windows), so these
+// host-independent tests are the primary guard for both runtimes.
+public class ScriptMapMinifierTests
+{
+    static (string Content, string? Map) Minify(params (string, string)[] files) =>
+        ScriptMapMinifier.Minify("app", files, new CodeSettings(), ";\n");
+
+    [Fact]
+    public void AppendsSourceMappingUrlComment_WhenMinified()
+    {
+        (string content, string? map) = Minify(("~/a.js", "function alpha(name) { return 'hi ' + name; }"));
+
+        Assert.EndsWith("//# sourceMappingURL=app.min.js.map", content.TrimEnd());
+        Assert.NotNull(map);
+    }
+
+    [Fact]
+    public void Map_ListsEverySource()
+    {
+        (_, string? map) = Minify(
+            ("~/a.js", "function alpha(name) { return 'hi ' + name; }"),
+            ("~/b.js", "function beta(x) { return x * 2; }"));
+
+        using JsonDocument doc = JsonDocument.Parse(map!);
+        List<string> sources = [.. doc.RootElement.GetProperty("sources").EnumerateArray().Select(s => s.GetString()!)];
+        Assert.Contains("~/a.js", sources);
+        Assert.Contains("~/b.js", sources);
+    }
+
+    [Fact]
+    public void PreMinifiedFile_PassesThroughVerbatim()
+    {
+        const string preMinified = "var already=minified;";
+        (string content, _) = Minify(("~/lib.min.js", preMinified));
+
+        Assert.Contains(preMinified, content);
+    }
+
+    [Fact]
+    public void OnlyPreMinifiedFiles_ProduceNoMap()
+    {
+        (string content, string? map) = Minify(("~/lib.min.js", "var a=1;"), ("~/other.min.js", "var b=2;"));
+
+        Assert.Null(map);
+        Assert.DoesNotContain("sourceMappingURL", content);
+    }
+}

--- a/tests/DragonBundles.Tests/SystemWeb/NUglifyTransformTests.cs
+++ b/tests/DragonBundles.Tests/SystemWeb/NUglifyTransformTests.cs
@@ -57,18 +57,18 @@ public class NUglifyTransformTests
     public void NUglifyScriptTransform_Process_HonorsCodeSettings()
     {
         BundleResponse kept = MakeResponse("/*! license */\nfunction f() { return 1; }");
-        new NUglifyScriptTransform(new CodeSettings { PreserveImportantComments = true }).Process(null!, kept);
+        new NUglifyScriptTransform("app", new CodeSettings { PreserveImportantComments = true }).Process(null!, kept);
         Assert.Contains("/*! license */", kept.Content);
 
         BundleResponse stripped = MakeResponse("/*! license */\nfunction f() { return 1; }");
-        new NUglifyScriptTransform(new CodeSettings { PreserveImportantComments = false }).Process(null!, stripped);
+        new NUglifyScriptTransform("app", new CodeSettings { PreserveImportantComments = false }).Process(null!, stripped);
         Assert.DoesNotContain("/*! license */", stripped.Content);
     }
 
     [Fact]
     public void NUglifyScriptTransform_Process_MinifiesJs()
     {
-        NUglifyScriptTransform transform = new();
+        NUglifyScriptTransform transform = new("app");
         BundleResponse response = MakeResponse("function hello() { return 'hi'; }");
 
         transform.Process(null!, response);
@@ -80,7 +80,7 @@ public class NUglifyTransformTests
     [Fact]
     public void NUglifyScriptTransform_Process_SetsJsContentType()
     {
-        NUglifyScriptTransform transform = new();
+        NUglifyScriptTransform transform = new("app");
         BundleResponse response = MakeResponse("var x=1;");
 
         transform.Process(null!, response);
@@ -91,10 +91,25 @@ public class NUglifyTransformTests
     [Fact]
     public void NUglifyScriptTransform_Process_NullContextDoesNotThrow()
     {
-        NUglifyScriptTransform transform = new();
+        NUglifyScriptTransform transform = new("app");
         BundleResponse response = MakeResponse("var x=1;");
 
         Exception? ex = Record.Exception(() => transform.Process(null!, response));
         Assert.Null(ex);
+    }
+
+    [Fact]
+    public void SourceMapStore_RoundTrips()
+    {
+        SourceMapStore.Set("round-trip-bundle", "{\"version\":3}");
+
+        Assert.True(SourceMapStore.TryGet("round-trip-bundle", out string map));
+        Assert.Equal("{\"version\":3}", map);
+    }
+
+    [Fact]
+    public void SourceMapStore_Miss_ReturnsFalse()
+    {
+        Assert.False(SourceMapStore.TryGet("never-stored-bundle", out _));
     }
 }

--- a/tests/DragonBundles.Tests/SystemWeb/SourceMapServingTests.cs
+++ b/tests/DragonBundles.Tests/SystemWeb/SourceMapServingTests.cs
@@ -1,0 +1,57 @@
+using System.Web;
+using System.Web.Optimization;
+using System.Web.Routing;
+
+namespace DragonBundles.Tests.SystemWeb;
+
+// Covers the net48-specific source-map serving glue that does NOT need a hosting environment:
+// the handler (built over a hand-constructed HttpContext) and the route AddScriptBundle registers.
+// The transform's Files->pairs path (BundleFile.ApplyTransforms / VirtualPathUtility.ToAbsolute)
+// needs a live host and is left to ScriptMapMinifierTests + manual verification.
+public class SourceMapServingTests
+{
+    static HttpContext MakeContext(out StringWriter body)
+    {
+        body = new StringWriter();
+        return new HttpContext(
+            new HttpRequest("map", "http://localhost/bundles/js/app.min.js.map", ""),
+            new HttpResponse(body));
+    }
+
+    [Fact]
+    public void Handler_ServesStoredMapAsJson()
+    {
+        SourceMapStore.Set("serve-bundle", "{\"version\":3,\"sources\":[\"/Scripts/app.js\"]}");
+        HttpContext context = MakeContext(out StringWriter body);
+
+        new SourceMapHandler("serve-bundle").ProcessRequest(context);
+        context.Response.Flush();
+
+        Assert.Equal("application/json", context.Response.ContentType);
+        Assert.Contains("\"version\":3", body.ToString());
+    }
+
+    [Fact]
+    public void Handler_Returns404_WhenMapNotStored()
+    {
+        HttpContext context = MakeContext(out _);
+
+        new SourceMapHandler("never-stored-bundle").ProcessRequest(context);
+
+        Assert.Equal(404, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public void AddScriptBundle_RegistersMapRouteAtIndexZero()
+    {
+        BundleCollection bundles = [];
+
+        bundles.AddScriptBundle("app", "~/Scripts/app.js");
+
+        // Registered once, inserted at the front so a catch-all MVC route can't shadow it.
+        RouteBase first = RouteTable.Routes[0];
+        Route route = Assert.IsType<Route>(first);
+        Assert.Equal("bundles/js/{name}.min.js.map", route.Url);
+        Assert.IsType<SourceMapRouteHandler>(route.RouteHandler);
+    }
+}


### PR DESCRIPTION
Brings JS source maps to the classic ASP.NET (net48) target for parity with ASP.NET Core. Script bundles now emit a V3 source map plus a `//# sourceMappingURL={name}.min.js.map` comment, and serve the map at `~/bundles/js/{name}.min.js.map`.

## Approach

- **Shared logic, both TFMs.** The map-generation logic (per-file minify loop, pre-minified passthrough with output-line tracking, single trailing `sourceMappingURL`) is extracted into a TFM-neutral `ScriptMapMinifier`, sharing `DeferredSourceMap`. `ScriptBundleProvider.Minify` (net10) is refactored to a thin adapter over it, so both runtimes produce byte-identical maps. Both files are compiled into the net48 target via explicit `Compile Include`.
- **net48 transform.** `NUglifyScriptTransform` is handed already-concatenated content, so it rebuilds the per-file `(sourceUrl, content)` pairs from `BundleResponse.Files` (`BundleFile.ApplyTransforms()` + `IncludedVirtualPath`) to feed the shared helper. Source paths are normalized with `VirtualPathUtility.ToAbsolute` (`~/Scripts/app.js` → `/Scripts/app.js`) so devtools can resolve the originals — matching net10's web-absolute `sources`. Falls back to a plain minify (no map) when `Files` is unavailable.
- **Serving.** The generated map is kept in-memory (`SourceMapStore`, no disk — matching the ASP.NET Core target) and served by `SourceMapHandler` as `application/json` with non-immutable caching. `AddScriptBundle` registers one route (inserted at index 0 so a catch-all MVC route can't shadow it, once) mapping `bundles/js/{name}.min.js.map` to the handler.

## Tests

- `ScriptMapMinifierTests` (net8/net10) — host-independent contract for the shared helper: sourceMappingURL append, per-source listing, pre-minified passthrough, no-map when all inputs are pre-minified. This is the primary guard for the map logic on both runtimes.
- `SourceMapServingTests` + `SourceMapStore` round-trip (net48) — host-free coverage of the serving glue: handler serves stored map / returns 404, and `AddScriptBundle` registers the route at index 0.

## Verification

All three TFMs build clean under the CI flag; 93 tests pass on net8 and net10; net48 test project compiles; format clean. The 47-test net10 source-map suite is green, confirming the shared-helper refactor is behavior-preserving.

**Windows-only caveat:** the transform's `Files` → `ApplyTransforms`/`ToAbsolute` path needs a live host, so it isn't exercised by automated tests (the net48 unit tests hit the no-map fallback; the map logic is covered via the shared helper on net10). Worth a one-time devtools check on Windows, and confirming `BundleResponse.Files` is populated when the bundle-level transform runs.

Closes #46.
