### PR TITLE
Emit Subresource Integrity hashes on classic ASP.NET (net48) bundle tags (#45)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ BundleConfigurator : IBundleConfigurator
 Three types are public:
 
 - `BundleCollectionExtensions` — `BundleCollection.AddStyleBundle(name, files...)` and `AddScriptBundle(name, files...)`, plus `ConfigureBundling(Action<BundlingOptions>)` for global NUglify settings (mirrors ASP.NET Core's `AddBundling`; options are held per-`BundleCollection` via a `ConditionalWeakTable` and read when bundles are registered). Registers bundles at `~/bundles/css/{name}` and `~/bundles/js/{name}` with NUglify transforms.
-- `HtmlHelperExtensions` — `@Html.StyleBundle(name)` and `@Html.ScriptBundle(name)`. Wraps `Styles.Render` / `Scripts.Render` with the internal virtual path.
+- `HtmlHelperExtensions` — `@Html.StyleBundle(name)` and `@Html.ScriptBundle(name)`. When optimizations are enabled, hand-builds the bundle tag with `integrity="sha384-..." crossorigin="anonymous" data-bundle="{name}"` (matching the ASP.NET Core tag helpers); when off, falls back to `Styles.Render` / `Scripts.Render` (per-file tags, no SRI).
 - `BundlingOptions` — shared, TFM-neutral minification settings type (also public on net10.0), configured here via `ConfigureBundling`.
 
 Internal types:
@@ -90,6 +90,13 @@ Script bundles emit a V3 source map plus a trailing `//# sourceMappingURL={name}
 - net10.0: `ScriptBundleProvider.Minify()` builds `(sourceUrl, content)` pairs from `env.WebRootPath` and calls the helper; the map is stored on `bundle.SourceMap` and served in-memory at `{name}.min.js.map`.
 - net48: `NUglifyScriptTransform` rebuilds the pairs from `BundleResponse.Files` (via `BundleFile.ApplyTransforms()` + `IncludedVirtualPath`) — the transform is handed already-concatenated content, so per-file info must come from `Files` — calls the helper, and stashes the map in the static in-memory `SourceMapStore` keyed by bundle name. `AddScriptBundle` registers one `System.Web.Routing.Route` (inserted at index 0, once) mapping `bundles/js/{name}.min.js.map` to `SourceMapHandler`, which serves the stored map as `application/json` with non-immutable caching. When `BundleResponse.Files` is unavailable (e.g. a unit test setting `Content` directly), the transform falls back to minifying the combined content with no map.
 
+### subresource integrity (SRI)
+
+Both TFMs emit `integrity="sha384-<base64>" crossorigin="anonymous"` on production bundle tags. The `sha384-` computation lives in the TFM-neutral `SriHash.Compute(...)` (compiled into net48 via explicit `Compile Include`; uses `SHA384.HashData` on net8/net10 and `SHA384.Create().ComputeHash` on net48 behind `#if NET5_0_OR_GREATER` since the static API is .NET 5+).
+
+- net10.0: `BundleProvider.UpdateHashes()` hashes `bundle.MinifiedContent` at startup into `bundle.Integrity`; tag helpers stamp it.
+- net48: `HtmlHelperExtensions` hashes the served bytes at render time — `bundle.GenerateBundleResponse(context).Content`, which runs the full transform pipeline (so the hash covers the JS `sourceMappingURL` comment) and reuses the same server cache the bundle handler serves from. Hand-builds the tag with `SriHash.Compute(...)`. `BuildLinkTag` / `BuildScriptTag` are the tag formatters (host-free, unit-tested). Falls back to `Styles.Render` / `Scripts.Render` when `BundleTable.EnableOptimizations` is false or the bundle is unregistered.
+
 ### tests
 
 Tests live in `tests/DragonBundles.Tests/`. Internal types are exposed via `InternalsVisibleTo`. The project also multi-targets `net8.0;net10.0;net48` using the same conditional compile pattern as the main library.
@@ -99,10 +106,13 @@ Tests live in `tests/DragonBundles.Tests/`. Internal types are exposed via `Inte
 - `StyleTagHelperTests` / `ScriptTagHelperTests` — tag helper HTML output in dev vs production. Use real `TagHelperContext`/`TagHelperOutput` — no mocking needed.
 - `BundlingIntegrationTests` — end-to-end HTTP tests using `TestServer` via `BundlingTestFixture` (`IClassFixture`). Verifies bundles are served at the correct URLs with correct content types and minified content; also confirms static files still pass through the `CompositeFileProvider`.
 - `ScriptMapMinifierTests` — host-independent contract for the shared `ScriptMapMinifier` (sourceMappingURL append, per-source listing, pre-minified passthrough, no-map when all inputs are pre-minified). Primary local guard for source-map behavior on both TFMs since the net48 transform's map path only runs on a live host.
+- `SriHashTests` — host-independent contract for the shared `SriHash` (`sha384-<base64>`, matches an independent SHA-384, deterministic/content-sensitive). Guards the SRI algorithm for both TFMs.
 
 **net48 tests** (`tests/DragonBundles.Tests/SystemWeb/`):
 - `NUglifyTransformTests` — `IBundleTransform` implementations (these hit the `Files == null` fallback, so the map path is covered by `ScriptMapMinifierTests`, not here) plus `SourceMapStore` round-trip. Uses a real `BundleResponse` with `null` context (transforms don't access context).
 - `BundleCollectionExtensionsTests` — verifies virtual path registration and NUglify transform wiring via `GetBundleFor()`. Uses a fresh `new BundleCollection()` per test (never `BundleTable.Bundles`).
+- `SourceMapServingTests` — host-free coverage of the source-map handler (serve/404) and the route `AddScriptBundle` registers.
+- `HtmlHelperExtensionsTests` — host-free coverage of the SRI tag format (`BuildLinkTag` / `BuildScriptTag`). The render-time integrity computation needs a live host and is verified on Windows.
 
 net48 tests compile on Mac but only run on Windows. CI runs them on a `windows-latest` GitHub Actions runner.
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Dev/prod rendering is controlled by `BundleTable.EnableOptimizations` — indivi
 
 Script bundles emit a [source map](https://developer.mozilla.org/en-US/docs/Glossary/Source_map) referenced from the minified file (`//# sourceMappingURL={name}.min.js.map`) and served at `~/bundles/js/{name}.min.js.map`, so browser devtools resolve the bundle back to the original source files — parity with the ASP.NET Core target. `AddScriptBundle` registers the route that serves it, so no extra wiring is needed.
 
+When optimizations are enabled, `@Html.StyleBundle` / `@Html.ScriptBundle` render the bundle tag with a [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) hash and `crossorigin="anonymous"` (`integrity="sha384-..."` over the exact served bytes) — matching the ASP.NET Core tag helpers. In debug (optimizations off), they fall back to plain per-file tags with no SRI. The hash assumes bundles are served as UTF-8 (the default); a non-UTF-8 `<globalization responseEncoding>` would change the served bytes and break the integrity check.
+
 To control NUglify's output, call `ConfigureBundling` before registering bundles — the same
 global model as ASP.NET Core's `AddBundling`:
 

--- a/src/DragonBundles/BundleProvider.cs
+++ b/src/DragonBundles/BundleProvider.cs
@@ -111,7 +111,7 @@ abstract class BundleProvider<T>(IWebHostEnvironment env, string bundleDirectory
 
         byte[] bytes = Encoding.UTF8.GetBytes(bundle.MinifiedContent);
         bundle.Version = Convert.ToHexString(SHA256.HashData(bytes))[..8].ToLowerInvariant();
-        bundle.Integrity = "sha384-" + Convert.ToBase64String(SHA384.HashData(bytes));
+        bundle.Integrity = SriHash.Compute(bytes);
     }
 
     public List<string> GetSourceUrls(string name) =>

--- a/src/DragonBundles/DragonBundles.csproj
+++ b/src/DragonBundles/DragonBundles.csproj
@@ -38,9 +38,10 @@
     <Compile Remove="**\*.cs" />
     <Compile Include="SystemWeb\**\*.cs" />
     <Compile Include="BundlingOptions.cs" />
-    <!-- TFM-neutral source-map helpers shared with the ASP.NET Core target -->
+    <!-- TFM-neutral helpers shared with the ASP.NET Core target -->
     <Compile Include="ScriptMapMinifier.cs" />
     <Compile Include="DeferredSourceMap.cs" />
+    <Compile Include="SriHash.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">

--- a/src/DragonBundles/SriHash.cs
+++ b/src/DragonBundles/SriHash.cs
@@ -1,0 +1,27 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace DragonBundles;
+
+/// <summary>
+/// Computes a <a href="https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity">
+/// Subresource Integrity</a> string (<c>sha384-&lt;base64&gt;</c>) over a bundle's served bytes.
+/// TFM-neutral so both runtimes emit identical hashes: the hash must cover the exact bytes the
+/// browser downloads, so callers pass the final post-minification content.
+/// </summary>
+static class SriHash
+{
+    public static string Compute(byte[] content)
+    {
+        // The static SHA384.HashData does not exist on net48; ComputeHash there yields identical bytes.
+#if NET5_0_OR_GREATER
+        byte[] hash = SHA384.HashData(content);
+#else
+        using SHA384 sha = SHA384.Create();
+        byte[] hash = sha.ComputeHash(content);
+#endif
+        return "sha384-" + Convert.ToBase64String(hash);
+    }
+
+    public static string Compute(string content) => Compute(Encoding.UTF8.GetBytes(content));
+}

--- a/src/DragonBundles/SystemWeb/HtmlHelperExtensions.cs
+++ b/src/DragonBundles/SystemWeb/HtmlHelperExtensions.cs
@@ -7,10 +7,44 @@ public static class HtmlHelperExtensions
     {
         /// <summary>Renders the CSS bundle registered under <paramref name="name"/>.</summary>
         public static IHtmlString StyleBundle(string name) =>
-            Styles.Render($"~/bundles/css/{name}");
+            Render($"~/bundles/css/{name}", name, css: true);
 
         /// <summary>Renders the JavaScript bundle registered under <paramref name="name"/>.</summary>
         public static IHtmlString ScriptBundle(string name) =>
-            Scripts.Render($"~/bundles/js/{name}");
+            Render($"~/bundles/js/{name}", name, css: false);
     }
+
+    static IHtmlString Render(string virtualPath, string name, bool css)
+    {
+        Bundle bundle = BundleTable.Bundles.GetBundleFor(virtualPath);
+
+        // When optimizations are off (debug), System.Web serves individual unbundled files, so there
+        // is no single bundle to hash — fall back to the framework's per-file rendering with no SRI.
+        // Mirrors the ASP.NET Core tag helpers' Development branch.
+        if (bundle is null || !BundleTable.EnableOptimizations)
+        {
+            return css ? Styles.Render(virtualPath) : Scripts.Render(virtualPath);
+        }
+
+        string integrity = ComputeIntegrity(bundle, virtualPath);
+        string url = (css ? Styles.Url(virtualPath) : Scripts.Url(virtualPath)).ToHtmlString();
+        return new MvcHtmlString(css ? BuildLinkTag(url, integrity, name) : BuildScriptTag(url, integrity, name));
+    }
+
+    // Hashes the post-transform bundle content — the exact bytes the bundle handler serves, including
+    // the JS sourceMappingURL comment — so the SRI hash matches what the browser downloads.
+    // GenerateBundleResponse uses the same server cache the handler does, so the two agree.
+    static string ComputeIntegrity(Bundle bundle, string virtualPath)
+    {
+        BundleContext context = new(new HttpContextWrapper(HttpContext.Current), BundleTable.Bundles, virtualPath);
+        BundleResponse response = bundle.GenerateBundleResponse(context);
+        return SriHash.Compute(response.Content);
+    }
+
+    // Attribute shape matches the ASP.NET Core tag helpers for parity.
+    internal static string BuildLinkTag(string url, string integrity, string name) =>
+        $"<link rel=\"stylesheet\" href=\"{url}\" integrity=\"{integrity}\" crossorigin=\"anonymous\" data-bundle=\"{name}\" />";
+
+    internal static string BuildScriptTag(string url, string integrity, string name) =>
+        $"<script src=\"{url}\" integrity=\"{integrity}\" crossorigin=\"anonymous\" data-bundle=\"{name}\"></script>";
 }

--- a/tests/DragonBundles.Tests/SriHashTests.cs
+++ b/tests/DragonBundles.Tests/SriHashTests.cs
@@ -1,0 +1,31 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace DragonBundles.Tests;
+
+public class SriHashTests
+{
+    [Fact]
+    public void Compute_MatchesIndependentSha384Base64()
+    {
+        const string content = "body{color:red}";
+        byte[] bytes = Encoding.UTF8.GetBytes(content);
+        string expected = "sha384-" + Convert.ToBase64String(SHA384.HashData(bytes));
+
+        Assert.Equal(expected, SriHash.Compute(content));
+        Assert.Equal(expected, SriHash.Compute(bytes));
+    }
+
+    [Fact]
+    public void Compute_HasSha384Prefix()
+    {
+        Assert.StartsWith("sha384-", SriHash.Compute("x"));
+    }
+
+    [Fact]
+    public void Compute_IsDeterministicAndContentSensitive()
+    {
+        Assert.Equal(SriHash.Compute("a"), SriHash.Compute("a"));
+        Assert.NotEqual(SriHash.Compute("a"), SriHash.Compute("b"));
+    }
+}

--- a/tests/DragonBundles.Tests/SystemWeb/HtmlHelperExtensionsTests.cs
+++ b/tests/DragonBundles.Tests/SystemWeb/HtmlHelperExtensionsTests.cs
@@ -1,0 +1,27 @@
+namespace DragonBundles.Tests.SystemWeb;
+
+// Host-free coverage of the SRI tag format. Emitting the tags at render time needs BundleTable +
+// HttpContext (a live host), so that path is verified on Windows; the tag shape — the parity-
+// critical part — is locked here.
+public class HtmlHelperExtensionsTests
+{
+    [Fact]
+    public void BuildLinkTag_EmitsStylesheetWithIntegrityAndCrossorigin()
+    {
+        string tag = HtmlHelperExtensions.BuildLinkTag("/bundles/css/site?v=abc123", "sha384-ZZZ", "site");
+
+        Assert.Equal(
+            "<link rel=\"stylesheet\" href=\"/bundles/css/site?v=abc123\" integrity=\"sha384-ZZZ\" crossorigin=\"anonymous\" data-bundle=\"site\" />",
+            tag);
+    }
+
+    [Fact]
+    public void BuildScriptTag_EmitsScriptWithIntegrityAndCrossorigin()
+    {
+        string tag = HtmlHelperExtensions.BuildScriptTag("/bundles/js/app?v=abc123", "sha384-ZZZ", "app");
+
+        Assert.Equal(
+            "<script src=\"/bundles/js/app?v=abc123\" integrity=\"sha384-ZZZ\" crossorigin=\"anonymous\" data-bundle=\"app\"></script>",
+            tag);
+    }
+}


### PR DESCRIPTION
Brings Subresource Integrity to the classic ASP.NET (net48) target for parity with ASP.NET Core. `@Html.StyleBundle` / `@Html.ScriptBundle` now render the bundle tag with `integrity="sha384-..." crossorigin="anonymous"` (plus `data-bundle`), matching the ASP.NET Core tag helpers.

## Approach

- **Shared hash, both TFMs.** The `sha384-<base64>` computation is extracted into a TFM-neutral `SriHash`. net10's `BundleProvider.UpdateHashes` is refactored to call it (behavior-preserving). Uses `SHA384.HashData` on net8/net10 and `SHA384.Create().ComputeHash` on net48 behind `#if NET5_0_OR_GREATER`, since the static API is .NET 5+.
- **Hash the served bytes.** `HtmlHelperExtensions` hashes `bundle.GenerateBundleResponse(context).Content` — the exact post-transform bytes the bundle handler serves, reusing the same server cache. Because it hashes the pipeline output (not a re-minification), the hash naturally covers the JS `//# sourceMappingURL` comment from #46, so the two features compose safely.
- **Hand-built tags.** `Styles.Render` / `Scripts.Render` expose no hook for arbitrary attributes, so the tag is built directly (`BuildLinkTag` / `BuildScriptTag`) to match net10's exact attribute shape. Falls back to `Styles/Scripts.Render` (per-file tags, no SRI) when `BundleTable.EnableOptimizations` is off or the bundle is unregistered — mirroring the ASP.NET Core Development branch.

## Tests

- `SriHashTests` (net8/net10) — algorithm contract: `sha384-<base64>`, matches an independent SHA-384, deterministic/content-sensitive.
- `HtmlHelperExtensionsTests` (net48) — host-free lock on the tag format (integrity + crossorigin + data-bundle).

## Verification

All three TFMs build clean under the CI flag; 96 tests pass on net8/net10 (incl. the 14-test net10 integrity/tag-helper suite confirming the `SriHash` refactor is byte-identical); net48 compiles; format clean.

## ⚠️ Required Windows gate before merge/ship

SRI is a browser **hard-fail**: if the hashed bytes don't match what System.Web's `BundleHandler` writes, the browser *blocks* the resource. That write path has no automated coverage (net48 CI runs under `dotnet test`, not IIS), so this is the acceptance test for #45 and must pass on a real host:

1. Run on Windows with optimizations on, render a page.
2. `curl` the bundle URL, compute `sha384-` + base64(SHA384(raw bytes)), assert it equals the rendered `integrity` attribute.
3. Confirm the browser shows no SRI block.

**Caveat (documented):** the hash assumes UTF-8 response encoding (the default). A non-UTF-8 `<globalization responseEncoding>` would change the served bytes and break the check; net10 is immune since it serves raw bytes.

Closes #45.
